### PR TITLE
Fast improve for more automatization capabilities

### DIFF
--- a/lgsm/functions/check_steamcmd.sh
+++ b/lgsm/functions/check_steamcmd.sh
@@ -16,7 +16,14 @@ fn_install_steamcmd(){
 }
 
 fn_check_steamcmd_user(){
-	# Checks if steamuser is setup.
+	# Check if steamuser is setup in ENV.
+	if [ -n "${globalsteamuser}" ]; then
+		fn_print_ok_eol_nl
+		fn_print_info "Steam Credentials taken from environment variables"
+		steamuser="${globalsteamuser}"
+		steampass="${globalsteampass}"
+	fi
+	# Checks if steamuser is setup in config file.
 	if [ "${steamuser}" == "username" ]; then
 		fn_print_fail_nl "Steam login not set. Update steamuser in ${selfname}."
 		echo "	* Change steamuser=\"username\" to a valid steam login."


### PR DESCRIPTION
If you need use LGSM as automatically installer you should edit (for example) arkserver file. Not too automated, uncomfortably.

And after operations on the server credentials from Steam account stay in file — it not secure, i think.

I see another way — just use environment variables for steamuser && steampass like as:
"globalsteamuser=user globalsteampass=pass ./sbserver install"

You can run install, start or stop operations without any trace of yours Steam credentials, of course if you not logging console history or cleaning up it by simple command "history -c".

Also, if you run this command from another server (for example, automation controller server) any changes in files and any cleaning not required — it's awesome.