### PR TITLE
Fix for Bug #1049

### DIFF
--- a/lgsm/functions/command_fastdl.sh
+++ b/lgsm/functions/command_fastdl.sh
@@ -160,6 +160,7 @@ fn_gmod_fastdl(){
 	fn_script_log "Copying map files"
 	sleep 0.5
 	find . -name '*.bsp' | cpio --quiet -updm "${fastdldir}"
+	find . -name '*.ain' | cpio --quiet -updm "${fastdldir}"
 	fn_print_ok "Map files copied"
 	sleep 0.5
 	echo -en "\n"


### PR DESCRIPTION
This commit should fix the issue with Bug #1049 not Commiting graph
files for maps to the FastDL server by searching for files with the .ain
extension.