### PR TITLE
[master] Fixed Project Zomboid config handling

### DIFF
--- a/ProjectZomboid/pzserver
+++ b/ProjectZomboid/pzserver
@@ -14,7 +14,7 @@ if [ -f ".dev-debug" ]; then
 	set -x
 fi
 
-version="161113"
+version="161118"
 
 ##########################
 ######## Settings ########
@@ -27,7 +27,7 @@ adminpassword="CHANGE_ME"
 ip="0.0.0.0"
 
 fn_parms(){
-parms="-ip ${ip} -adminpassword \"${adminpassword}\""
+parms="-ip ${ip} -adminpassword \"${adminpassword}\" -servername ${servicename}"
 }
 
 #### LinuxGSM Settings ####
@@ -96,8 +96,8 @@ filesdir="${rootdir}/serverfiles"
 systemdir="${filesdir}"
 executabledir="${filesdir}"
 executable="./start-server.sh"
-servercfg="server.ini"
-servercfgdefault="server.cfg"
+servercfg="${servicename}.ini"
+servercfgdefault="server.ini"
 servercfgdir="${HOME}/Zomboid/Server"
 servercfgfullpath="${servercfgdir}/${servercfg}"
 

--- a/ProjectZomboid/pzserver
+++ b/ProjectZomboid/pzserver
@@ -14,7 +14,7 @@ if [ -f ".dev-debug" ]; then
 	set -x
 fi
 
-version="161118"
+version="161113"
 
 ##########################
 ######## Settings ########

--- a/lgsm/functions/install_config.sh
+++ b/lgsm/functions/install_config.sh
@@ -298,6 +298,7 @@ elif [ "${gamename}" == "Pirates, Vikings, and Knights II" ]; then
 	fn_set_config_vars
 elif [ "${gamename}" == "Project Zomboid" ]; then
 	gamedirname="ProjectZomboid"
+	fn_check_cfgdir
 	array_configs+=( server.ini )
 	fn_fetch_default_config
 	fn_default_config_remote


### PR DESCRIPTION
- Corrected default config names
- Use service name for config and "server name"
- Added fn_check_cfgdir call to create non-existing config directory

Fixes #1190