### PR TITLE
Update rustserver

### DIFF
--- a/Rust/rustserver
+++ b/Rust/rustserver
@@ -29,6 +29,7 @@ ip="0.0.0.0"
 port="28015"
 rconport="28016"
 rconpassword="CHANGE_ME"
+rconweb="1"
 maxplayers="50"
 # Advanced Start Settings
 seed="" #  default random; range : 1 to 2147483647 ; used to change or reproduce a procedural map
@@ -39,7 +40,7 @@ tickrate="30" # default 30; range : 15 to 100
 ## Server Start Command | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters#additional-parameters
 # Edit with care | https://developer.valvesoftware.com/wiki/Rust_Dedicated_Server
 fn_parms(){
-parms="-batchmode +server.ip ${ip} +server.port ${port} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${servicename}\" ${conditionalseed} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile ${gamelogfile}"
+parms="-batchmode +server.ip ${ip} +server.port ${port} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${servicename}\" ${conditionalseed} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile ${gamelogfile}"
 }
 
 # Specific to Rust


### PR DESCRIPTION
Had issues logging in with experimental rcon after latest Rust Dedicated Server update, Caused disconnect loop. 
Warning asks to add rcon.web to startup script. This can be temporary or edited better but solves error > "You are connecting to your server via Experimental rcon type The support for this rcon type has been discontinued and can cause instabilities and crashes."