### PR TITLE
Fixes #1235

### DIFF
--- a/lgsm/functions/install_config.sh
+++ b/lgsm/functions/install_config.sh
@@ -23,17 +23,22 @@ fn_fetch_default_config(){
 # SERVERNAME to LinuxGSM
 # PASSWORD to random password
 fn_set_config_vars(){
-	random=$(strings /dev/urandom | grep -o '[[:alnum:]]' | head -n 8 | tr -d '\n'; echo)
-	servername="LinuxGSM"
-	rconpass="admin$random"
-	echo "changing hostname."
-	fn_script_log_info "changing hostname."
-	sleep 1
-	sed -i "s/SERVERNAME/${servername}/g" "${servercfgfullpath}"
-	echo "changing rcon/admin password."
-	fn_script_log_info "changing rcon/admin password."
-	sed -i "s/ADMINPASSWORD/${rconpass}/g" "${servercfgfullpath}"
-	sleep 1
+	if [ -f "${servercfgfullpath}" ]; then
+		random=$(strings /dev/urandom | grep -o '[[:alnum:]]' | head -n 8 | tr -d '\n'; echo)
+		servername="LinuxGSM"
+		rconpass="admin$random"
+		echo "changing hostname."
+		fn_script_log_info "changing hostname."
+		sleep 1
+		sed -i "s/SERVERNAME/${servername}/g" "${servercfgfullpath}"
+		echo "changing rcon/admin password."
+		fn_script_log_info "changing rcon/admin password."
+		sed -i "s/ADMINPASSWORD/${rconpass}/g" "${servercfgfullpath}"
+		sleep 1
+	else
+		fn_script_log_warn "Config file not found, cannot alter it."
+		echo "Config file not found, cannot alter it."
+		sleep 1
 }
 
 # Checks if cfg dir exists, creates it if it doesn't

--- a/lgsm/functions/install_config.sh
+++ b/lgsm/functions/install_config.sh
@@ -39,6 +39,7 @@ fn_set_config_vars(){
 		fn_script_log_warn "Config file not found, cannot alter it."
 		echo "Config file not found, cannot alter it."
 		sleep 1
+	fi
 }
 
 # Checks if cfg dir exists, creates it if it doesn't

--- a/lgsm/functions/install_config.sh
+++ b/lgsm/functions/install_config.sh
@@ -139,7 +139,6 @@ elif [ "${gamename}" == "ARK: Survivial Evolved" ]; then
 	array_configs+=( GameUserSettings.ini )
 	fn_fetch_default_config
 	fn_default_config_remote
-	fn_set_config_vars
 elif [ "${gamename}" == "ARMA 3" ]; then
 	gamedirname="Arma3"
 	fn_check_cfgdir

--- a/lgsm/functions/install_config.sh
+++ b/lgsm/functions/install_config.sh
@@ -134,6 +134,7 @@ if [ "${gamename}" == "7 Days To Die" ]; then
 	fn_set_config_vars
 elif [ "${gamename}" == "ARK: Survivial Evolved" ]; then
 	gamedirname="ARKSurvivalEvolved"
+	fn_check_cfgdir
 	array_configs+=( GameUserSettings.ini )
 	fn_fetch_default_config
 	fn_default_config_remote


### PR DESCRIPTION
Fixes #1235

Ark had no config file out of the box because its directory didn't exist. Because of that, it wouldn't work out of the box.
Also, LGSM tried to alter config file even if it didn't exist. It's solved by an simple if -f check.

Working on this, I noticed another issue. Let's quote myself:
> Admin password and servername are present into Ark but set within start parameters, so their edition by LGSM is pointless since they will be reset upon server shutdown into the config file, taking start parms values.

So I just removed fn_set_config_vars for Ark.

Ultimately, I have some concerns that need to be checked about Ark's default config file:
Port values might need to be removed from default config file since they are ignored and start parameters are used instead,. On top of that, those are not changed within the config file upon server shutdown to match start parameters, so in the end, if they're not used, they can be misleading. Somebody should test without them into the config file and see if it still works as intended. My guess is it does work perfectly.