### PR TITLE
Urgent fix for #1239 (broken Steam login)

### DIFF
--- a/7DaysToDie/sdtdserver
+++ b/7DaysToDie/sdtdserver
@@ -24,7 +24,7 @@ version="170110"
 
 ## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
 steamuser="username"
-steampass="password"
+steampass='password'
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 ip="0.0.0.0"

--- a/Arma3/arma3server
+++ b/Arma3/arma3server
@@ -24,7 +24,7 @@ version="170110"
 
 ## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
 steamuser="username"
-steampass="password"
+steampass='password'
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 ip="0.0.0.0"

--- a/BladeSymphony/bsserver
+++ b/BladeSymphony/bsserver
@@ -24,7 +24,7 @@ version="170110"
 
 ## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
 steamuser="username"
-steampass="password"
+steampass='password'
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 defaultmap="duel_winter"

--- a/BrainBread2/bb2server
+++ b/BrainBread2/bb2server
@@ -23,7 +23,7 @@ version="170110"
 ## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
 # Steam login
 steamuser="username"
-steampass="password"
+steampass='password'
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 defaultmap="bba_barracks"

--- a/KillingFloor/kfserver
+++ b/KillingFloor/kfserver
@@ -24,7 +24,7 @@ version="170110"
 
 ## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
 steamuser="username"
-steampass="password"
+steampass='password'
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 defaultmap="KF-BioticsLab.rom"

--- a/NS2Combat/ns2cserver
+++ b/NS2Combat/ns2cserver
@@ -24,7 +24,7 @@ version="170110"
 
 ## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
 steamuser="username"
-steampass="password"
+steampass='password'
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 defaultmap="co_core"

--- a/NaturalSelection2/ns2server
+++ b/NaturalSelection2/ns2server
@@ -24,7 +24,7 @@ version="170110"
 
 ## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
 steamuser="username"
-steampass="password"
+steampass='password'
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 defaultmap="ns2_summit"

--- a/RedOrchestra/roserver
+++ b/RedOrchestra/roserver
@@ -24,7 +24,7 @@ version="170110"
 
 ## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
 steamuser="username"
-steampass="password"
+steampass='password'
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 defaultmap="RO-Arad.rom"

--- a/Ricochet/ricochetserver
+++ b/Ricochet/ricochetserver
@@ -41,10 +41,6 @@ parms="-game ricochet -strictportbind +ip ${ip} -port ${port} +clientport ${clie
 
 #### Server Settings ####
 
-## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
-steamuser="username"
-steampass="password"
-
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 ip="0.0.0.0"
 

--- a/Starbound/sbserver
+++ b/Starbound/sbserver
@@ -24,7 +24,7 @@ version="170110"
 
 ## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
 steamuser="username"
-steampass="password"
+steampass='password'
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 ip="0.0.0.0"

--- a/Teeworlds/twserver
+++ b/Teeworlds/twserver
@@ -24,7 +24,7 @@ version="170110"
 
 ## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
 steamuser="username"
-steampass="password"
+steampass='password'
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 ip="0.0.0.0"

--- a/Terraria/terrariaserver
+++ b/Terraria/terrariaserver
@@ -24,7 +24,7 @@ version="170110"
 
 ## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
 steamuser="username"
-steampass="password"
+steampass='password'
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 ip="0.0.0.0"

--- a/lgsm/functions/check_steamcmd.sh
+++ b/lgsm/functions/check_steamcmd.sh
@@ -31,7 +31,7 @@ fn_check_steamcmd_user(){
 			fn_script_log_info "Using anonymous Steam login."
 		fi
 		steamuser="anonymous"
-		steampass=""
+		steampass=''
 		sleep 1
 	fi
 }

--- a/lgsm/functions/check_steamcmd.sh
+++ b/lgsm/functions/check_steamcmd.sh
@@ -58,7 +58,7 @@ fn_check_steamcmd_sh(){
 fn_check_steamcmd_guard(){
 	if [ "${function_selfname}" == "command_update.sh" ]||[ "${function_selfname}" == "command_validate.sh" ]; then
 		# Checks that SteamCMD is working correctly and will prompt Steam Guard if required.
-		"${steamcmddir}"/steamcmd.sh +login "${steamuser}" '${steampass}' +quit
+		"${steamcmddir}"/steamcmd.sh +login "${steamuser}" "${steampass}" +quit
 		if [ $? -ne 0 ]; then
 			fn_print_failure_nl "Error running SteamCMD"
 		fi

--- a/lgsm/functions/command_validate.sh
+++ b/lgsm/functions/command_validate.sh
@@ -24,9 +24,9 @@ fn_validation(){
 	fi
 
 	if [ "${engine}" == "goldsource" ]; then
-		${unbuffer} ./steamcmd.sh +login "${steamuser}" '${steampass}' +force_install_dir "${filesdir}" +app_set_config 90 mod ${appidmod} +app_update "${appid}" ${branch} +app_update "${appid}" ${branch} validate +quit| tee -a "${scriptlog}"
+		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod ${appidmod} +app_update "${appid}" ${branch} +app_update "${appid}" ${branch} validate +quit| tee -a "${scriptlog}"
 	else
-		${unbuffer} ./steamcmd.sh +login "${steamuser}" '${steampass}' +force_install_dir "${filesdir}" +app_update "${appid}" ${branch} validate +quit| tee -a "${scriptlog}"
+		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" ${branch} validate +quit| tee -a "${scriptlog}"
 	fi
 	if [ $? != 0 ]; then
 		fn_print_fail_nl "Validating files: SteamCMD"

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -78,18 +78,18 @@ fn_install_server_files_steamcmd(){
 
 			if [ "${counter}" -le "4" ]; then
 				if [ "${engine}" == "goldsource" ]; then
-					${unbuffer} ./steamcmd.sh +login "${steamuser}" '${steampass}' +force_install_dir "${filesdir}" +app_set_config 90 mod "${appidmod}" +app_update "${appid}" ${branch} +quit
+					${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod "${appidmod}" +app_update "${appid}" ${branch} +quit
 					local exitcode=$?
 				else
-					${unbuffer} ./steamcmd.sh +login "${steamuser}" '${steampass}' +force_install_dir "${filesdir}" +app_update "${appid}" ${branch} +quit
+					${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" ${branch} +quit
 					local exitcode=$?
 				fi
 			elif [ "${counter}" -ge "5" ]; then
 				if [ "${engine}" == "goldsource" ]; then
-					${unbuffer} ./steamcmd.sh +login "${steamuser}" '${steampass}' +force_install_dir "${filesdir}" +app_set_config 90 mod "${appidmod}" +app_update "${appid}" ${branch} -validate +quit
+					${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod "${appidmod}" +app_update "${appid}" ${branch} -validate +quit
 					local exitcode=$?
 				else
-					${unbuffer} ./steamcmd.sh +login "${steamuser}" '${steampass}' +force_install_dir "${filesdir}" +app_update "${appid}" ${branch} -validate +quit
+					${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" ${branch} -validate +quit
 					local exitcode=$?
 				fi
 			fi
@@ -107,7 +107,7 @@ fn_install_server_files_steamcmd(){
 		counter="0"
 		while [ "${counter}" -le "4" ]; do
 			counter=$((counter+1))
-			${unbuffer} ./steamcmd.sh +login "${steamuser}" '${steampass}' +force_install_dir "${filesdir}" +app_set_config 90 mod ${appidmod} +app_update "${appid}" ${branch} -validate +quit
+			${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod ${appidmod} +app_update "${appid}" ${branch} -validate +quit
 			local exitcode=$?
 		done
 	fi

--- a/lgsm/functions/update_steamcmd.sh
+++ b/lgsm/functions/update_steamcmd.sh
@@ -26,9 +26,9 @@ fn_update_steamcmd_dl(){
 	fi
 
 	if [ "${engine}" == "goldsource" ]; then
-		${unbuffer} ./steamcmd.sh +login "${steamuser}" '${steampass}' +force_install_dir "${filesdir}" +app_set_config 90 mod ${appidmod} +app_update "${appid}" ${branch} +quit | tee -a "${scriptlog}"
+		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_set_config 90 mod ${appidmod} +app_update "${appid}" ${branch} +quit | tee -a "${scriptlog}"
 	else
-		${unbuffer} ./steamcmd.sh +login "${steamuser}" '${steampass}' +force_install_dir "${filesdir}" +app_update "${appid}" ${branch} +quit | tee -a "${scriptlog}"
+		${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${filesdir}" +app_update "${appid}" ${branch} +quit | tee -a "${scriptlog}"
 	fi
 
 	fix.sh
@@ -156,7 +156,7 @@ fn_update_steamcmd_check(){
 	fi
 
 	# Gets availablebuild info
-	availablebuild=$(./steamcmd.sh +login "${steamuser}" '${steampass}' +app_info_update 1 +app_info_print "${appid}" +app_info_print "${appid}" +quit | grep -EA 1000 "^\s+\"branches\"$" | grep -EA 5 "^\s+\"${branchname}\"$" | grep -m 1 -EB 10 "^\s+}$" | grep -E "^\s+\"buildid\"\s+" | tr '[:blank:]"' ' ' | tr -s ' ' | cut -d\  -f3)
+	availablebuild=$(./steamcmd.sh +login "${steamuser}" "${steampass}" +app_info_update 1 +app_info_print "${appid}" +app_info_print "${appid}" +quit | grep -EA 1000 "^\s+\"branches\"$" | grep -EA 5 "^\s+\"${branchname}\"$" | grep -m 1 -EB 10 "^\s+}$" | grep -E "^\s+\"buildid\"\s+" | tr '[:blank:]"' ' ' | tr -s ' ' | cut -d\  -f3)
 	if [ -z "${availablebuild}" ]; then
 		fn_print_fail "Checking for update: SteamCMD"
 		sleep 1


### PR DESCRIPTION
Fixes #1239
I just put the single quotes into the right location: The variable. Not the output of the variable, which just prevents it from expanding.

This is an emergency fix since it prevents all game servers that require login from working.