### PR TITLE
Fix for config issues

### DIFF
--- a/ARKSurvivalEvolved/arkserver
+++ b/ARKSurvivalEvolved/arkserver
@@ -23,18 +23,16 @@ version="170110"
 #### Server Settings ####
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
-servername="LGSM ARK Server"
 port="7777"
 queryport="27015"
 rconport="27020"
-rconpassword="" # Set to enable rcon
-maxplayers="60"
+maxplayers="70"
 ip="0.0.0.0"
 
 ## Server Start Command | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters#additional-parameters
 # Edit with care
 fn_parms(){
-parms="\"TheIsland?listen?MultiHome=${ip}?SessionName=${servername}?MaxPlayers=${maxplayers}?QueryPort=${queryport}?RCONPort=${rconport}?Port=${port}?ServerAdminPassword=${rconpassword}\""
+parms="\"TheIsland?listen?MultiHome=${ip}?MaxPlayers=${maxplayers}?QueryPort=${queryport}?RCONPort=${rconport}?Port=${port}?\""
 }
 
 #### LinuxGSM Settings ####

--- a/ARKSurvivalEvolved/arkserver
+++ b/ARKSurvivalEvolved/arkserver
@@ -23,7 +23,7 @@ version="170110"
 #### Server Settings ####
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
-servername="ark-server"
+servername="LGSM ARK Server"
 port="7777"
 queryport="27015"
 rconport="27020"

--- a/ARKSurvivalEvolved/arkserver
+++ b/ARKSurvivalEvolved/arkserver
@@ -80,7 +80,7 @@ githubbranch="master"
 
 ## LinuxGSM Server Details
 # Do not edit
-gamename="ARK: Survivial Evolved"
+gamename="ARK: Survival Evolved"
 engine="unreal4"
 
 ## Service Name | https://github.com/GameServerManagers/LinuxGSM/wiki/Multiple-Servers

--- a/ARKSurvivalEvolved/arkserver
+++ b/ARKSurvivalEvolved/arkserver
@@ -24,11 +24,11 @@ version="170110"
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 servername="ark-server"
-port="7778"
+port="7777"
 queryport="27015"
-rconport="32330"
+rconport="27020"
 rconpassword="" # Set to enable rcon
-maxplayers="50"
+maxplayers="60"
 ip="0.0.0.0"
 
 ## Server Start Command | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters#additional-parameters

--- a/lgsm/functions/command_details.sh
+++ b/lgsm/functions/command_details.sh
@@ -350,7 +350,7 @@ fn_details_ark(){
 		echo -e "DESCRIPTION\tDIRECTION\tPORT\tPROTOCOL"
 		echo -e "> Game\tINBOUND\t${port}\tudp"
 		# Don't do arithmetics if ever the port wasn't a numeric value
-		if [ "${port}" -eq "${port}" ];then 
+		if [ "${port}" -eq "${port}" ]; then 
 			echo -e "> RAW\t\INBOUND\t$((port+1))\tudp
 		fi
 		echo -e "> Query\tINBOUND\t${queryport}\tudp"

--- a/lgsm/functions/command_details.sh
+++ b/lgsm/functions/command_details.sh
@@ -351,10 +351,10 @@ fn_details_ark(){
 		echo -e "> Game\tINBOUND\t${port}\tudp"
 		# Don't do arithmetics if ever the port wasn't a numeric value
 		if [ "${port}" -eq "${port}" ]; then 
-			echo -e "> RAW\t\INBOUND\t$((port+1))\tudp"
+			echo -e "> RAW\tINBOUND\t$((port+1))\tudp"
 		fi
 		echo -e "> Query\tINBOUND\t${queryport}\tudp"
-		echo -e "> RCON\INBOUND\t${rconport}\ttcp"
+		echo -e "> RCON\tINBOUND\t${rconport}\ttcp"
 	} | column -s $'\t' -t
 }
 

--- a/lgsm/functions/command_details.sh
+++ b/lgsm/functions/command_details.sh
@@ -351,7 +351,7 @@ fn_details_ark(){
 		echo -e "> Game\tINBOUND\t${port}\tudp"
 		# Don't do arithmetics if ever the port wasn't a numeric value
 		if [ "${port}" -eq "${port}" ]; then 
-			echo -e "> RAW\t\INBOUND\t$((port+1))\tudp
+			echo -e "> RAW\t\INBOUND\t$((port+1))\tudp"
 		fi
 		echo -e "> Query\tINBOUND\t${queryport}\tudp"
 		echo -e "> RCON\INBOUND\t${rconport}\ttcp"

--- a/lgsm/functions/command_details.sh
+++ b/lgsm/functions/command_details.sh
@@ -777,7 +777,7 @@ fn_display_details() {
 		fn_details_ut3
 	elif [ "${gamename}" == "7 Days To Die" ]; then
 		fn_details_sdtd
-	elif [ "${gamename}" == "ARK: Survivial Evolved" ]; then
+	elif [ "${gamename}" == "ARK: Survival Evolved" ]; then
 		fn_details_ark
 	elif [ "${gamename}" == "Call of Duty" ]; then
 		fn_details_cod

--- a/lgsm/functions/command_details.sh
+++ b/lgsm/functions/command_details.sh
@@ -347,9 +347,14 @@ fn_details_ark(){
 	echo -e "netstat -atunp | grep ShooterGame"
 	echo -e ""
 	{
-		echo -e "DESCRIPTION\tDIRECTION\tPORT\tPROTOCOL\tINI VARIABLE"
-		echo -e "> Game\tINBOUND\t${port}\tudp\tPort=${port}"
+		echo -e "DESCRIPTION\tDIRECTION\tPORT\tPROTOCOL"
+		echo -e "> Game\tINBOUND\t${port}\tudp"
+		# Don't do arithmetics if ever the port wasn't a numeric value
+		if [ "${port}" -eq "${port}" ];then 
+			echo -e "> RAW\t\INBOUND\t$((port+1))\tudp
+		fi
 		echo -e "> Query\tINBOUND\t${queryport}\tudp"
+		echo -e "> RCON\INBOUND\t${rconport}\ttcp"
 	} | column -s $'\t' -t
 }
 

--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -296,7 +296,7 @@ fn_stop_tmux(){
 		rm -f "${rootdir}/${lockselfname}"
 		# ARK doesn't clean up immediately after tmux is killed.
 				# Make certain the ports are cleared before continuing.
-				if [ "${gamename}" == "ARK: Survivial Evolved" ]; then
+				if [ "${gamename}" == "ARK: Survival Evolved" ]; then
 						fn_stop_ark
 						echo -en "\n"
 				fi

--- a/lgsm/functions/info_config.sh
+++ b/lgsm/functions/info_config.sh
@@ -39,6 +39,16 @@ fn_info_config_avalanche(){
 	fi
 }
 
+fn_info_config_ark(){
+	if [ ! -f "${servercfgfullpath}" ]; then
+		servername="${unavailable}"
+	else
+		servername=$(grep "Name" "${servercfgfullpath}" | sed -e 's/^[ \t]*//g' -e '/^--/d' -e 's/SessionName//g' | tr -d '=\";,:' | sed -e 's/^[ \t]*//' -e 's/[ \t]*$//')
+		# Not Set
+		servername=${servername:-"NOT SET"}
+	fi
+}
+
 fn_info_config_bf1942(){
 	if [ ! -f "${servercfgfullpath}" ]; then
 		servername="${unavailable}"
@@ -596,6 +606,9 @@ fn_info_config_sdtd(){
 # Just Cause 2
 if [ "${engine}" == "avalanche" ]; then
 	fn_info_config_avalanche
+# ARK: Survival Evolved
+elif [ "${gamename}" == "ARK: Survivial Evolved" ]; then
+	fn_info_config_ark
 # Battlefield: 1942
 elif [ "${gamename}" == "Battlefield: 1942" ]; then
 	fn_info_config_bf1942

--- a/lgsm/functions/info_config.sh
+++ b/lgsm/functions/info_config.sh
@@ -43,7 +43,7 @@ fn_info_config_ark(){
 	if [ ! -f "${servercfgfullpath}" ]; then
 		servername="${unavailable}"
 	else
-		servername=$(grep "Name" "${servercfgfullpath}" | sed -e 's/^[ \t]*//g' -e '/^--/d' -e 's/SessionName//g' | tr -d '=\";,:' | sed -e 's/^[ \t]*//' -e 's/[ \t]*$//')
+		servername=$(grep "SessionName" "${servercfgfullpath}" | sed -e 's/^[ \t]*//g' -e '/^--/d' -e 's/SessionName//g' | tr -d '=\";,:' | sed -e 's/^[ \t]*//' -e 's/[ \t]*$//')
 		# Not Set
 		servername=${servername:-"NOT SET"}
 	fi

--- a/lgsm/functions/install_config.sh
+++ b/lgsm/functions/install_config.sh
@@ -136,6 +136,7 @@ elif [ "${gamename}" == "ARK: Survivial Evolved" ]; then
 	array_configs+=( GameUserSettings.ini )
 	fn_fetch_default_config
 	fn_default_config_remote
+	fn_set_config_vars
 elif [ "${gamename}" == "ARMA 3" ]; then
 	gamedirname="Arma3"
 	fn_check_cfgdir

--- a/lgsm/functions/install_config.sh
+++ b/lgsm/functions/install_config.sh
@@ -8,35 +8,7 @@ local commandname="INSTALL"
 local commandaction="Install"
 local function_selfname="$(basename $(readlink -f "${BASH_SOURCE[0]}"))"
 
-fn_fetch_default_config(){
-	mkdir -pv "${lgsmdir}/default-configs"
-	githuburl="https://github.com/GameServerManagers/Game-Server-Configs/master"
-
-	for config in "${array_configs[@]}"
-	do
-		fileurl="https://raw.githubusercontent.com/GameServerManagers/Game-Server-Configs/master/${gamedirname}/${config}"; filedir="${lgsmdir}/default-configs"; filename="${config}";  executecmd="noexecute" run="norun"; force="noforce"
-		fn_fetch_file "${fileurl}" "${filedir}" "${filename}" "${executecmd}" "${run}" "${force}" "${md5}"
-	done
-}
-
-# Changes some variables within the default configs
-# SERVERNAME to LinuxGSM
-# PASSWORD to random password
-fn_set_config_vars(){
-	random=$(strings /dev/urandom | grep -o '[[:alnum:]]' | head -n 8 | tr -d '\n'; echo)
-	servername="LinuxGSM"
-	rconpass="admin$random"
-	echo "changing hostname."
-	fn_script_log_info "changing hostname."
-	sleep 1
-	sed -i "s/SERVERNAME/${servername}/g" "${servercfgfullpath}"
-	echo "changing rcon/admin password."
-	fn_script_log_info "changing rcon/admin password."
-	sed -i "s/ADMINPASSWORD/${rconpass}/g" "${servercfgfullpath}"
-	sleep 1
-}
-
-# Checks if cfg dir exists, creates it if it doesn't
+# Checks if server cfg dir exists, creates it if it doesn't
 fn_check_cfgdir(){
 	if [ ! -d "${servercfgdir}" ]; then
 		echo "creating ${servercfgdir} config directory."
@@ -45,11 +17,19 @@ fn_check_cfgdir(){
 	fi
 }
 
-# Copys the default configs from Game-Server-Configs repo to the
-# correct location
+# Downloads default configs from Game-Server-Configs repo to lgsm/default-configs
+fn_fetch_default_config(){
+	mkdir -pv "${lgsmdir}/default-configs"
+	githuburl="https://github.com/GameServerManagers/Game-Server-Configs/master"
+	for config in "${array_configs[@]}"; do
+		fileurl="https://raw.githubusercontent.com/GameServerManagers/Game-Server-Configs/master/${gamedirname}/${config}"; filedir="${lgsmdir}/default-configs"; filename="${config}";  executecmd="noexecute" run="norun"; force="noforce"
+		fn_fetch_file "${fileurl}" "${filedir}" "${filename}" "${executecmd}" "${run}" "${force}" "${md5}"
+	done
+}
+
+# Copys default configs from Game-Server-Configs repo to server config location
 fn_default_config_remote(){
-	for config in "${array_configs[@]}"
-	do
+	for config in "${array_configs[@]}"; do
 		# every config is copied
 		echo "copying ${config} config file."
 		fn_script_log_info "copying ${servercfg} config file."
@@ -64,6 +44,29 @@ fn_default_config_remote(){
 		fi
 	done
 	sleep 1
+}
+
+# Changes some variables within the default configs
+# SERVERNAME to LinuxGSM
+# PASSWORD to random password
+fn_set_config_vars(){
+	if [ -f "${servercfgfullpath}" ]; then
+		random=$(strings /dev/urandom | grep -o '[[:alnum:]]' | head -n 8 | tr -d '\n'; echo)
+		servername="LinuxGSM"
+		rconpass="admin$random"
+		echo "changing hostname."
+		fn_script_log_info "changing hostname."
+		sleep 1
+		sed -i "s/SERVERNAME/${servername}/g" "${servercfgfullpath}"
+		echo "changing rcon/admin password."
+		fn_script_log_info "changing rcon/admin password."
+		sed -i "s/ADMINPASSWORD/${rconpass}/g" "${servercfgfullpath}"
+		sleep 1
+	else
+		fn_script_log_warn "Config file not found, cannot alter it."
+		echo "Config file not found, cannot alter it."
+		sleep 1
+	fi
 }
 
 # Changes some variables within the default Don't Starve Together configs
@@ -129,10 +132,10 @@ if [ "${gamename}" == "7 Days To Die" ]; then
 	fn_set_config_vars
 elif [ "${gamename}" == "ARK: Survivial Evolved" ]; then
 	gamedirname="ARKSurvivalEvolved"
+	fn_check_cfgdir
 	array_configs+=( GameUserSettings.ini )
 	fn_fetch_default_config
 	fn_default_config_remote
-	fn_set_config_vars
 elif [ "${gamename}" == "ARMA 3" ]; then
 	gamedirname="Arma3"
 	fn_check_cfgdir

--- a/lgsm/functions/install_config.sh
+++ b/lgsm/functions/install_config.sh
@@ -130,7 +130,7 @@ if [ "${gamename}" == "7 Days To Die" ]; then
 	fn_fetch_default_config
 	fn_default_config_remote
 	fn_set_config_vars
-elif [ "${gamename}" == "ARK: Survivial Evolved" ]; then
+elif [ "${gamename}" == "ARK: Survival Evolved" ]; then
 	gamedirname="ARKSurvivalEvolved"
 	fn_check_cfgdir
 	array_configs+=( GameUserSettings.ini )


### PR DESCRIPTION
ARK
- No more duplicates between .ini and start parms ( fixes #1104 )
- More relevant ports info in command_details.sh
- Added into info_config.sh to get SessionName (servername) from it
- Create config directory before trying to copy config file ( fixes #1235 )

GLOBAL
install_config.sh
- Conditional check for existing cfg file before trying to alter it
- Reworked order and comments
- One liner `for whatever; do` to fit `if` syntax.

Screenshots
http://imgur.com/a/OFPtp