### PR TITLE
Adjustment to debug mode

### DIFF
--- a/lgsm/functions/command_debug.sh
+++ b/lgsm/functions/command_debug.sh
@@ -106,6 +106,9 @@ else
 	${executable} ${parms}
 fi
 
+fn_print_dots "Stopping debug"
+sleep 1
+fn_print_ok_nl "Stopping debug"
 # remove trap.
 trap - INT
 core_exit.sh


### PR DESCRIPTION
Right now when a debug mode is ran and the user aborts the server with Cntrl+C or the server crashes, it leaves a message that kinda seems like LGSM failed:

```
[ OK ] Debug ark-server: Starting debug
Using binned.
4.5.1-0+UE4 7038 3077 402 6
[S_API FAIL] SteamAPI_Init() failed; SteamAPI_IsSteamRunning() failed.
Setting breakpad minidump AppID = 346110
^CCtrlCHandler: Signal=2
/home/arkserver1/lgsm/functions/command_debug.sh: line 107: 29308 Aborted ${executable} ${parms}
```

I did some searching around and it doesn't seem like you can remove bash outputting the "Aborted" message, so I thought we could at least end the message off with LGSM confirming that it is stopping it's debug mode.