### PR TITLE
Minecraft fix for improper default executable

### DIFF
--- a/Minecraft/mcserver
+++ b/Minecraft/mcserver
@@ -86,7 +86,7 @@ filesdir="${rootdir}/serverfiles"
 ## Server Specific Directories
 systemdir="${filesdir}"
 executabledir="${filesdir}"
-executable="java -Xmx${javaram}M -jar minecraft_server.jar"
+executable="java -Xmx${javaram}M -jar ${filesdir}/minecraft_server.jar"
 servercfg="server.properties"
 servercfgdefault="server.properties"
 servercfgdir="${filesdir}"


### PR DESCRIPTION
I have no idea how this was not noticed before.
Without this change the following will happen:
[ FAIL ] Starting mc-server: Executable java -Xmx1024M -jar minecraft_server.jar was not found