### PR TITLE
Loads of minor fixes

### DIFF
--- a/Rust/rustserver
+++ b/Rust/rustserver
@@ -39,7 +39,7 @@ tickrate="30" # default 30; range : 15 to 100
 
 ## Server Start Command | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters#additional-parameters
 fn_parms(){
-parms="-batchmode +server.ip ${ip} +server.port ${port} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${servicename}\" ${conditionalseed} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile ${gamelogfile}"
+parms="-batchmode +server.ip ${ip} +server.port ${port} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${servicename}\" ${conditionalseed} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile \"${gamelogdate}\""
 }
 
 # Specific to Rust
@@ -132,7 +132,6 @@ backupdir="${rootdir}/backups"
 gamelogdir="${rootdir}/log/server"
 scriptlogdir="${rootdir}/log/script"
 consolelogdir="${rootdir}/log/console"
-gamelog="${gamelogdir}/${servicename}-game.log"
 scriptlog="${scriptlogdir}/${servicename}-script.log"
 consolelog="${consolelogdir}/${servicename}-console.log"
 emaillog="${scriptlogdir}/${servicename}-email.log"
@@ -140,7 +139,7 @@ emaillog="${scriptlogdir}/${servicename}-email.log"
 ## Logs Naming
 scriptlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
-gamelogfile="\"gamelog-$(date '+%Y-%m-%d-%H-%M-%S').log\""
+gamelogdate="${gamelogdir}/${servicename}-game-$(date '+%Y-%m-%d-%H:%M:%S').log"
 
 ########################
 ######## Script ########

--- a/lgsm/functions/check.sh
+++ b/lgsm/functions/check.sh
@@ -17,7 +17,7 @@ if [ "${function_selfname}" != "command_monitor.sh" ];then
 	check_permissions.sh
 fi
 
-if [ "${function_selfname}" != "command_install.sh" ]&&[ "${function_selfname}" != "command_update_functions.sh" ]; then
+if [ "${function_selfname}" != "command_install.sh" ]&&[ "${function_selfname}" != "command_update_functions.sh" ]&&[ "${function_selfname}" != "command_details.sh" ]&&[ "${function_selfname}" != "command_postdetails.sh" ]; then
 	check_system_dir.sh
 fi
 
@@ -53,7 +53,7 @@ do
 	fi
 done
 
-local allowed_commands_array=( command_console.sh command_debug.sh command_details.sh command_monitor.sh command_start.sh command_stop.sh )
+local allowed_commands_array=( command_console.sh command_debug.sh command_monitor.sh command_start.sh command_stop.sh )
 for allowed_command in "${allowed_commands_array[@]}"
 do
 	if [ "${allowed_command}" == "${function_selfname}" ]; then

--- a/lgsm/functions/check_executable.sh
+++ b/lgsm/functions/check_executable.sh
@@ -9,9 +9,10 @@ local function_selfname="$(basename $(readlink -f "${BASH_SOURCE[0]}"))"
 
 # Check if executable exists
 if [ ! -f "${executabledir}/${execname}" ]; then
-	fn_script_log_warn "Expected executable not found: ${executabledir}/${execname}"
+	fn_script_log_warn "Executable was not found: ${executabledir}/${execname}"
 	if [ -d "${scriptlogdir}" ]; then
-		fn_print_fail_nl "Executable ${execname} was not found"
+		fn_print_fail_nl "Executable was not found:"
+		echo " * ${executabledir}/${execname}"
 	fi
 	exitcode="1"
 	core_exit.sh

--- a/lgsm/functions/check_logs.sh
+++ b/lgsm/functions/check_logs.sh
@@ -7,11 +7,20 @@
 local commandname="CHECK"
 local function_selfname="$(basename $(readlink -f "${BASH_SOURCE[0]}"))"
 
-# Create directories for the script and console logs
-if [ ! -d "${scriptlogdir}" ]||[ ! -d "${consolelogdir}" ]&&[ "${gamename}" != "TeamSpeak 3" ]; then
+fn_check_logs(){
 	fn_print_dots "Checking for log files"
 	sleep 0.5
 	fn_print_info_nl "Checking for log files: Creating log files"
 	checklogs=1
 	install_logs.sh
+}
+
+# Create directories for the script and console logs
+if [ ! -d "${scriptlogdir}" ]||[ ! -d "${consolelogdir}" ]&&[ "${gamename}" != "TeamSpeak 3" ]; then
+	fn_check_logs
+fi
+
+# Create gamelogdir if variable exist but dir doesn't exist
+if [ -n "${gamelogdir}" ]&&[ ! -d "${gamelogdir}" ]; then
+	fn_check_logs
 fi

--- a/lgsm/functions/check_logs.sh
+++ b/lgsm/functions/check_logs.sh
@@ -20,7 +20,7 @@ if [ ! -d "${scriptlogdir}" ]||[ ! -d "${consolelogdir}" ]&&[ "${gamename}" != "
 	fn_check_logs
 fi
 
-# Create gamelogdir if variable exist but dir doesn't exist
+# Create gamelogdir if variable exist but dir does not exist
 if [ -n "${gamelogdir}" ]&&[ ! -d "${gamelogdir}" ]; then
 	fn_check_logs
 fi

--- a/lgsm/functions/check_permissions.sh
+++ b/lgsm/functions/check_permissions.sh
@@ -232,4 +232,6 @@ fn_sys_perm_error_process(){
 ## Run checks
 fn_check_ownership
 fn_check_permissions
-fn_sys_perm_error_process
+if [ "${function_selfname}" == "command_start.sh" ]; then
+	fn_sys_perm_error_process
+fi

--- a/lgsm/functions/command_update.sh
+++ b/lgsm/functions/command_update.sh
@@ -11,7 +11,7 @@ local function_selfname="$(basename $(readlink -f "${BASH_SOURCE[0]}"))"
 fn_print_dots ""
 sleep 0.5
 check.sh
-
+logs.sh
 
 if [ "${gamename}" == "TeamSpeak 3" ]; then
 	update_ts3.sh

--- a/lgsm/functions/install_logs.sh
+++ b/lgsm/functions/install_logs.sh
@@ -15,12 +15,22 @@ if [ "${checklogs}" != "1" ]; then
 fi
 sleep 1
 # Create dir's for the script and console logs
-mkdir -v "${rootdir}/log"
-mkdir -v "${scriptlogdir}"
-touch "${scriptlog}"
+if [ ! -d "${rootdir}/log" ]; then
+	mkdir -v "${rootdir}/log"
+fi
+if [ ! -d "${scriptlogdir}" ]; then
+	mkdir -v "${scriptlogdir}"
+fi
+if [ ! -f "${scriptlog}" ]; then
+	touch "${scriptlog}"
+fi
 if [ -n "${consolelogdir}" ]; then
-	mkdir -v "${consolelogdir}"
-	touch "${consolelog}"
+	if [ ! -d "${consolelogdir}" ]; then
+		mkdir -v "${consolelogdir}"
+	fi
+	if [ ! -f "${consolelog}" ]; then
+		touch "${consolelog}"
+	fi
 fi
 
 # If a server is source or goldsource, TeamSpeak 3, Starbound, Project Zomhoid create a symbolic link to the game server logs.
@@ -32,7 +42,9 @@ fi
 
 # If a server is unreal2 or unity3d create a dir.
 if [ "${engine}" == "unreal2" ]||[ "${engine}" == "unity3d" ]||[ "${gamename}" == "Teeworlds" ]||[ "${gamename}" == "seriousengine35" ]; then
-	mkdir -pv "${gamelogdir}"
+	if [ ! -d ${gamelogdir}" ]; then
+		mkdir -pv "${gamelogdir}"
+	fi
 fi
 
 # If server uses SteamCMD create a symbolic link to the Steam logs.

--- a/lgsm/functions/install_logs.sh
+++ b/lgsm/functions/install_logs.sh
@@ -15,22 +15,12 @@ if [ "${checklogs}" != "1" ]; then
 fi
 sleep 1
 # Create dir's for the script and console logs
-if [ ! -d "${rootdir}/log" ]; then
-	mkdir -v "${rootdir}/log"
-fi
-if [ ! -d "${scriptlogdir}" ]; then
-	mkdir -v "${scriptlogdir}"
-fi
-if [ ! -f "${scriptlog}" ]; then
-	touch "${scriptlog}"
-fi
+mkdir -v "${rootdir}/log"
+mkdir -v "${scriptlogdir}"
+touch "${scriptlog}"
 if [ -n "${consolelogdir}" ]; then
-	if [ ! -d "${consolelogdir}" ]; then
-		mkdir -v "${consolelogdir}"
-	fi
-	if [ ! -f "${consolelog}" ]; then
-		touch "${consolelog}"
-	fi
+	mkdir -v "${consolelogdir}"
+	touch "${consolelog}"
 fi
 
 # If a server is source or goldsource, TeamSpeak 3, Starbound, Project Zomhoid create a symbolic link to the game server logs.
@@ -42,9 +32,7 @@ fi
 
 # If a server is unreal2 or unity3d create a dir.
 if [ "${engine}" == "unreal2" ]||[ "${engine}" == "unity3d" ]||[ "${gamename}" == "Teeworlds" ]||[ "${gamename}" == "seriousengine35" ]; then
-	if [ ! -d "${gamelogdir}" ]; then
-		mkdir -pv "${gamelogdir}"
-	fi
+	mkdir -pv "${gamelogdir}"
 fi
 
 # If server uses SteamCMD create a symbolic link to the Steam logs.

--- a/lgsm/functions/install_logs.sh
+++ b/lgsm/functions/install_logs.sh
@@ -42,7 +42,7 @@ fi
 
 # If a server is unreal2 or unity3d create a dir.
 if [ "${engine}" == "unreal2" ]||[ "${engine}" == "unity3d" ]||[ "${gamename}" == "Teeworlds" ]||[ "${gamename}" == "seriousengine35" ]; then
-	if [ ! -d ${gamelogdir}" ]; then
+	if [ ! -d "${gamelogdir}" ]; then
 		mkdir -pv "${gamelogdir}"
 	fi
 fi

--- a/lgsm/functions/logs.sh
+++ b/lgsm/functions/logs.sh
@@ -16,7 +16,8 @@ if [ -n "${consolelog}" ]; then
 fi
 
 # For games not displaying a console, and having logs into their game directory
-if [ "${function_selfname}" == "command_start.sh" ] && [ -n "${gamelogfile}" ]; then
+check_status.sh
+if [ "${status}" != "0" ] && [ "${function_selfname}" == "command_start.sh" ] && [ -n "${gamelogfile}" ]; then
 	if [ -n "$(find "${systemdir}" -name "gamelog*.log")" ]; then
 		fn_print_info "Moving game logs to ${gamelogdir}"
 		fn_script_log_info "Moving game logs to ${gamelogdir}"

--- a/lgsm/functions/logs.sh
+++ b/lgsm/functions/logs.sh
@@ -101,10 +101,6 @@ if [ $(find "${scriptlogdir}"/ -type f -mtime +"${logdays}"|wc -l) -ne "0" ]; th
 		find "${legacyserverlogdir}"/ -type f -mtime +"${logdays}"| tee >> "${scriptlog}"
 		legacycount=$(find "${legacyserverlogdir}"/ -type f -mtime +"${logdays}"|wc -l)
 		find "${legacyserverlogdir}"/ -mtime +"${logdays}" -type f -exec rm -f {} \;
-		# Remove directory if empty
-		if [ ! "$(ls -A "${legacyserverlogdir}")" ]; then
-		rm -rf "${legacyserverlogdir}"
-		fi
 	fi
 
 	# Count total amount of files removed

--- a/lgsm/functions/update_steamcmd.sh
+++ b/lgsm/functions/update_steamcmd.sh
@@ -98,7 +98,11 @@ fn_update_request_log(){
 	fn_print_dots "Checking for update: Server logs"
 	fn_script_log_info "Checking for update: Server logs"
 	sleep 1
-	requestrestart=$(grep -Ec "MasterRequestRestart" "${consolelog}")
+	if [ -f ${consolelog} ]; then
+		requestrestart=$(grep -Ec "MasterRequestRestart" "${consolelog}")
+	else
+		requestrestart="0"
+	fi
 	if [ "${requestrestart}" -ge "1" ]; then
 		fn_print_ok_nl "Checking for update: Server logs: Update requested"
 		fn_script_log_pass "Checking for update: Server logs: Update requested"


### PR DESCRIPTION
- Rust now allows for custom log locations: log/gamelog
- `details `and `postdetails `commands can now be run even if server is not installed yet #1302
- If executable is not found, the full path will be displayed instead of just the executable name #1288
- Log rotation will now occur upon updates #1075
- Rust will not move gamelog if server is already started #1318
- Checks on /sys will now only occur upon server start #1303
- Fixed a possible error when ${consolelog} doesn't exist

Note: Log rotation already worked with monitor #1075


Also:
- Log directories will now only be created if they don't already exist.
- `gamelog` dir will be created if variable is set but dir doesn't exist
- Legacy server logs (log/server) won't be removed anymore if dir is empty