### PR TITLE
Fix logs keep being created with some games with a more general way of handling logs

### DIFF
--- a/lgsm/functions/command_console.sh
+++ b/lgsm/functions/command_console.sh
@@ -16,7 +16,6 @@ echo ""
 if ! fn_prompt_yn "Continue?" Y; then
 	echo Exiting; return
 fi
-done
 fn_print_dots "Accessing console"
 sleep 1
 check_status.sh

--- a/lgsm/functions/install_logs.sh
+++ b/lgsm/functions/install_logs.sh
@@ -14,7 +14,7 @@ if [ "${checklogs}" != "1" ]; then
 	echo "================================="
 fi
 sleep 1
-# Create dir's for the script and console logs
+# Create dirs for script and console logs
 mkdir -v "${rootdir}/log"
 mkdir -v "${scriptlogdir}"
 touch "${scriptlog}"
@@ -23,19 +23,19 @@ if [ -n "${consolelogdir}" ]; then
 	touch "${consolelog}"
 fi
 
-# If a server is source or goldsource, TeamSpeak 3, Starbound, Project Zomhoid create a symbolic link to the game server logs.
-if [ "${engine}" == "source" ]||[ "${engine}" == "goldsource" ]||[ "${gamename}" == "TeamSpeak 3" ]||[ "${engine}" == "starbound" ]||[ "${engine}" == "projectzomboid" ]||[ "${engine}" == "unreal" ]; then
+# Create gamelogdir if variable exists but directory does not
+if [ -n "${gamelogdir}" ]&&[ ! -d "${gamelogdir}" ]; then
+	mkdir -pv "${gamelogdir}"
+fi
+
+# Symlink gamelogdir to lgsm logs if variable exists
+if [ -n "${gamelogdir}" ]; then
 	if [ ! -h "${rootdir}/log/server" ]; then
 		ln -nfsv "${gamelogdir}" "${rootdir}/log/server"
 	fi
 fi
 
-# If a server is unreal2 or unity3d create a dir.
-if [ "${engine}" == "unreal2" ]||[ "${engine}" == "unity3d" ]||[ "${gamename}" == "Teeworlds" ]||[ "${gamename}" == "seriousengine35" ]; then
-	mkdir -pv "${gamelogdir}"
-fi
-
-# If server uses SteamCMD create a symbolic link to the Steam logs.
+# If server uses SteamCMD create a symbolic link to the Steam logs
 if [ -d "${rootdir}/Steam/logs" ]; then
 	if [ ! -h "${rootdir}/log/steamcmd" ]; then
 		ln -nfsv "${rootdir}/Steam/logs" "${rootdir}/log/steamcmd"

--- a/lgsm/functions/install_logs.sh
+++ b/lgsm/functions/install_logs.sh
@@ -14,7 +14,7 @@ if [ "${checklogs}" != "1" ]; then
 	echo "================================="
 fi
 sleep 1
-# Create dirs for script and console logs
+# Create script and console log directories
 mkdir -v "${rootdir}/log"
 mkdir -v "${scriptlogdir}"
 touch "${scriptlog}"


### PR DESCRIPTION
`gamelogdir `needs to be created if variable is set, otherwise `check_logs.sh` will attempt to create it upon almost any command if the server wasn't started yet and directory doesn't exist, as per https://github.com/GameServerManagers/LinuxGSM/blob/master/lgsm/functions/check_logs.sh#L24

symlink is done if `gamelogdir` variable is set rather than checking for what game it is, and after gamelogdir has been created (this order doesn't change anything, just a bit more elegant).

To sum up: Working with `if [ -n $"{gamelogdir}" }]` is a more general and simple way of doing it and shouldn't cause any kind of issue as long as gamelogdir variable is set to the proper path.

Thanks @Khelgar for reporting the issue