### PR TITLE
Add the ability to tame Titanosaurus on ARK server

### DIFF
--- a/ARKSurvivalEvolved/arkserver
+++ b/ARKSurvivalEvolved/arkserver
@@ -28,10 +28,11 @@ queryport="27015"
 rconport="27020"
 maxplayers="70"
 ip="0.0.0.0"
+titanotaming=false # Allow the taming of the Titanosaurus. true or false.
 
 ## Server Start Command | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters#additional-parameters
 fn_parms(){
-parms="\"TheIsland?listen?MultiHome=${ip}?MaxPlayers=${maxplayers}?QueryPort=${queryport}?RCONPort=${rconport}?Port=${port}?\""
+parms="\"TheIsland?listen?MultiHome=${ip}?MaxPlayers=${maxplayers}?QueryPort=${queryport}?RCONPort=${rconport}?Port=${port}?AllowRaidDinoFeeding=${titanotaming}\""
 }
 
 #### LinuxGSM Settings ####


### PR DESCRIPTION
This allow the taming of the [Titanosaurus](http://i.imgur.com/GVrg3gu.jpg) by adding true or false to a variable call `titanotaming`.

[Link to the patch](http://ark.gamepedia.com/243.0) that introduce the beast with his special server start parameters only for self hosted ark servers.

Are those type of PR ok ? I did that on my ARK PVE  LGSM powered server without any issue.