### PR TITLE
Fixes commands setting vars not working

### DIFF
--- a/lgsm/functions/core_getopt.sh
+++ b/lgsm/functions/core_getopt.sh
@@ -173,7 +173,7 @@ for i in "${optcommands[@]}"; do
 			for ((currcmdindex=1; currcmdindex <= ${currcmdamount}; currcmdindex++)); do
 				if [ "$(echo "${currentopt[index]}"| awk -F ';' -v x=${currcmdindex} '{ print $x }')" == "${getopt}" ]; then
 					# Run command
-					${currentopt[index+1]}
+					eval ${currentopt[index+1]}
 					core_exit.sh
 					break
 				fi


### PR DESCRIPTION
Some commands that require setting a variable, like "force-update" wouldn't work without this "eval" argument.

Example:
````
$ ./insserver fu
/home/insserver/lgsm/functions/core_getopt.sh: line 176: forceupdate=1;: command not found
````
This fixes the issue.

Tested on Debian & Ubuntu.