### PR TITLE
#1377 - Fixes an issue with compiled copies of tmux

### DIFF
--- a/lgsm/functions/command_start.sh
+++ b/lgsm/functions/command_start.sh
@@ -84,13 +84,13 @@ fn_start_tmux(){
 	tmux new-session -d -s "${servicename}" "${executable} ${parms}" 2> "${scriptlogdir}/.${servicename}-tmux-error.tmp"
 
 	# tmux pipe-pane not supported in tmux versions < 1.6
-	if [ "$(tmux -V|sed "s/tmux //"|sed -n '1 p'|tr -cd '[:digit:]')" -lt "16" ]; then
+	if [ "$(tmux -V|sed "s/tmux //"|sed -n '1 p'|tr -cd '[:digit:]')" -lt "16" ] 2>/dev/null; then
 		echo "Console logging disabled: Tmux => 1.6 required
 		https://gameservermanagers.com/tmux-upgrade
 		Currently installed: $(tmux -V)" > "${consolelog}"
 
 	# Console logging disabled: Bug in tmux 1.8 breaks logging
-	elif [ "$(tmux -V|sed "s/tmux //"|sed -n '1 p'|tr -cd '[:digit:]')" -eq "18" ]; then
+	elif [ "$(tmux -V|sed "s/tmux //"|sed -n '1 p'|tr -cd '[:digit:]')" -eq "18" ] 2>/dev/null; then
 		echo "Console logging disabled: Bug in tmux 1.8 breaks logging
 		https://gameservermanagers.com/tmux-upgrade
 		Currently installed: $(tmux -V)" > "${consolelog}"

--- a/lgsm/functions/command_start.sh
+++ b/lgsm/functions/command_start.sh
@@ -84,7 +84,7 @@ fn_start_tmux(){
 	tmux new-session -d -s "${servicename}" "${executable} ${parms}" 2> "${scriptlogdir}/.${servicename}-tmux-error.tmp"
 
 	# tmux pipe-pane not supported in tmux versions < 1.6
-	if [ "$(tmux -V|sed "s/tmux //"|sed -n '1 p'|tr -cd '[:digit:]')" -lt "16" ] 2>/dev/null; then
+	if [ "$(tmux -V|sed "s/tmux //"|sed -n '1 p'|tr -cd '[:digit:]')" -lt "16" ] 2>/dev/null; then # Tmux compiled from source will not return a number, therefore bypass this check and trash the error
 		echo "Console logging disabled: Tmux => 1.6 required
 		https://gameservermanagers.com/tmux-upgrade
 		Currently installed: $(tmux -V)" > "${consolelog}"

--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -37,12 +37,14 @@ glibcversion="$(ldd --version | sed -n '1s/.* //p')"
 
 ## tmux version
 # e.g: tmux 1.6
-if [ -z "$(command -v tmux)" ]; then
+if [ -z "$(command -V tmux)" ]; then
 	tmuxv="${red}NOT INSTALLED!${default}"
-elif [ "$(tmux -V|sed "s/tmux //" | sed -n '1 p' | tr -cd '[:digit:]')" -lt "16" ]; then
-	tmuxv="$(tmux -V) (>= 1.6 required for console log)"
 else
-	tmuxv=$(tmux -V)
+	if [ "$(tmux -V|sed "s/tmux //" | sed -n '1 p' | tr -cd '[:digit:]')" -lt "16" ] 2>/dev/null; then
+		tmuxv="$(tmux -V) (>= 1.6 required for console log)"
+	else
+		tmuxv=$(tmux -V)
+	fi
 fi
 
 ## Uptime


### PR DESCRIPTION
Fixes #1377 

Trash the integer error as it is not important or script breaking, will just display the version to the user in the `details` command stating it is from the master branch. It is up to the user to determine if the version they compiled is >= 1.6

I also updated the guide on how to compile tmux from source on the wiki.