### PR TITLE
Add tmux dimensions

### DIFF
--- a/lgsm/functions/command_start.sh
+++ b/lgsm/functions/command_start.sh
@@ -56,6 +56,20 @@ fn_start_teamspeak3(){
 
 fn_start_tmux(){
 	fn_parms
+	
+	# check for tmux size variables
+	if [[ ${tmux_width} =~ ^[0-9]+$ ]]
+	then
+		tmux-x=${tmux_width}
+	else
+		tmux-x=80
+	fi
+	if [[ ${tmux_height} =~ ^[0-9]+$ ]]
+	then
+		tmux-y=${tmux_height}
+	else
+		tmux-y=23
+	fi
 
 	# Log rotation
 	check_status.sh
@@ -81,7 +95,7 @@ fn_start_tmux(){
 	# Create lockfile
 	date > "${rootdir}/${lockselfname}"
 	cd "${executabledir}"
-	tmux new-session -d -s "${servicename}" "${executable} ${parms}" 2> "${scriptlogdir}/.${servicename}-tmux-error.tmp"
+	tmux new-session -d -x ${tmux-x} -y ${tmux-y} --s "${servicename}" "${executable} ${parms}" 2> "${scriptlogdir}/.${servicename}-tmux-error.tmp"
 
 	# tmux pipe-pane not supported in tmux versions < 1.6
 	if [ "$(tmux -V|sed "s/tmux //"|sed -n '1 p'|tr -cd '[:digit:]')" -lt "16" ]; then

--- a/lgsm/functions/command_start.sh
+++ b/lgsm/functions/command_start.sh
@@ -60,15 +60,15 @@ fn_start_tmux(){
 	# check for tmux size variables
 	if [[ ${tmux_width} =~ ^[0-9]+$ ]]
 	then
-		tmux-x=${tmux_width}
+		tmux_x=${tmux_width}
 	else
-		tmux-x=80
+		tmux_x=80
 	fi
 	if [[ ${tmux_height} =~ ^[0-9]+$ ]]
 	then
-		tmux-y=${tmux_height}
+		tmux_y=${tmux_height}
 	else
-		tmux-y=23
+		tmux_y=23
 	fi
 
 	# Log rotation
@@ -95,7 +95,7 @@ fn_start_tmux(){
 	# Create lockfile
 	date > "${rootdir}/${lockselfname}"
 	cd "${executabledir}"
-	tmux new-session -d -x ${tmux-x} -y ${tmux-y} -s "${servicename}" "${executable} ${parms}" 2> "${scriptlogdir}/.${servicename}-tmux-error.tmp"
+	tmux new-session -d -x ${tmux_x} -y ${tmux_y} -s "${servicename}" "${executable} ${parms}" 2> "${scriptlogdir}/.${servicename}-tmux-error.tmp"
 
 	# tmux pipe-pane not supported in tmux versions < 1.6
 	if [ "$(tmux -V|sed "s/tmux //"|sed -n '1 p'|tr -cd '[:digit:]')" -lt "16" ]; then

--- a/lgsm/functions/command_start.sh
+++ b/lgsm/functions/command_start.sh
@@ -95,7 +95,7 @@ fn_start_tmux(){
 	# Create lockfile
 	date > "${rootdir}/${lockselfname}"
 	cd "${executabledir}"
-	tmux new-session -d -x ${tmux-x} -y ${tmux-y} --s "${servicename}" "${executable} ${parms}" 2> "${scriptlogdir}/.${servicename}-tmux-error.tmp"
+	tmux new-session -d -x ${tmux-x} -y ${tmux-y} -s "${servicename}" "${executable} ${parms}" 2> "${scriptlogdir}/.${servicename}-tmux-error.tmp"
 
 	# tmux pipe-pane not supported in tmux versions < 1.6
 	if [ "$(tmux -V|sed "s/tmux //"|sed -n '1 p'|tr -cd '[:digit:]')" -lt "16" ]; then

--- a/lgsm/functions/command_start.sh
+++ b/lgsm/functions/command_start.sh
@@ -59,7 +59,7 @@ fn_start_tmux(){
 	
 	# check for tmux size variables
 	if [[ "${servercfgtmuxwidth}" =~ ^[0-9]+$ ]]; then
-		sessionwidth="${servercfgwidth}"
+		sessionwidth="${servercfgtmuxwidth}"
 	else
 		sessionwidth="80"
 	fi

--- a/lgsm/functions/command_start.sh
+++ b/lgsm/functions/command_start.sh
@@ -58,17 +58,15 @@ fn_start_tmux(){
 	fn_parms
 	
 	# check for tmux size variables
-	if [[ ${tmux_width} =~ ^[0-9]+$ ]]
-	then
-		tmux_x=${tmux_width}
+	if [[ "${servercfgtmuxwidth}" =~ ^[0-9]+$ ]]; then
+		sessionwidth="${servercfgwidth}"
 	else
-		tmux_x=80
+		sessionwidth="80"
 	fi
-	if [[ ${tmux_height} =~ ^[0-9]+$ ]]
-	then
-		tmux_y=${tmux_height}
+	if [[ "${servercfgtmuxheight}" =~ ^[0-9]+$ ]]; then
+		sessionheight="${servercfgtmuxheight}"
 	else
-		tmux_y=23
+		sessionheight="23"
 	fi
 
 	# Log rotation
@@ -95,7 +93,7 @@ fn_start_tmux(){
 	# Create lockfile
 	date > "${rootdir}/${lockselfname}"
 	cd "${executabledir}"
-	tmux new-session -d -x ${tmux_x} -y ${tmux_y} -s "${servicename}" "${executable} ${parms}" 2> "${scriptlogdir}/.${servicename}-tmux-error.tmp"
+	tmux new-session -d -x "${sessionheight}" -y "${sessionwidth}" -s "${servicename}" "${executable} ${parms}" 2> "${scriptlogdir}/.${servicename}-tmux-error.tmp"
 
 	# tmux pipe-pane not supported in tmux versions < 1.6
 	if [ "$(tmux -V|sed "s/tmux //"|sed -n '1 p'|tr -cd '[:digit:]')" -lt "16" ]; then


### PR DESCRIPTION
added the ability to set the default width and height of the detatched session using variables tmux_width and tmux_height.

these variables may be set at a local level or system wide.

the script checks if the input from the variables is a valid positive integer and if input is not a valid positive integer, sets the values for the tmux to the default values of 80x23

Fixes #1396