### PR TITLE
#1418 factorio experimental

### DIFF
--- a/Factorio/fctrserver
+++ b/Factorio/fctrserver
@@ -49,6 +49,7 @@ channeltag=""
 
 ## Updating | https://github.com/GameServerManagers/LinuxGSM/wiki/Update
 updateonstart="off"
+updatebranch="stable"
 
 ## Backup | https://github.com/GameServerManagers/LinuxGSM/wiki/Backup
 maxbackups="4"

--- a/lgsm/functions/core_dl.sh
+++ b/lgsm/functions/core_dl.sh
@@ -60,6 +60,8 @@ fn_dl_extract(){
 		tarcmd=$(tar -zxf "${filedir}/${filename}" -C "${extractdir}")
 	elif [ "${mime}" == "application/x-bzip2" ]; then
 		tarcmd=$(tar -jxf "${filedir}/${filename}" -C "${extractdir}")
+	elif [ "${mime}" == "application/x-xz" ]; then
+		tarcmd=$(tar -xf "${filedir}/${filename}" -C "${extractdir}")
 	elif [ "${mime}" == "application/zip" ]; then
 		tarcmd=$(unzip -d "${extractdir}" "${filedir}/${filename}")
 	fi

--- a/lgsm/functions/update_factorio.sh
+++ b/lgsm/functions/update_factorio.sh
@@ -76,7 +76,7 @@ fn_update_factorio_arch(){
 
 fn_update_factorio_availablebuild(){
 	# Gets latest build info.
-	availablebuild=$(curl -s https://www.factorio.com/download-headless/stable | grep 'headless/linux64' | head -n 1 | grep -oP '(?<=get-download/).*?(?=/)')
+	availablebuild=$(curl -s https://www.factorio.com/download-headless/"${updatebranch}" | grep 'headless/linux64' | head -n 1 | grep -oP '(?<=get-download/).*?(?=/)')
 	sleep 1
 
 	# Checks if availablebuild variable has been set

--- a/lgsm/functions/update_factorio.sh
+++ b/lgsm/functions/update_factorio.sh
@@ -49,7 +49,7 @@ fn_update_factorio_currentbuild(){
 	fi
 
 	# Get current build from logs
-	currentbuild=$(grep "Loading mod base" "${consolelogdir}"/"${servicename}"-console.log 2> /dev/null|awk '{print $5}')
+	currentbuild=$(grep "Loading mod base" "${consolelogdir}"/"${servicename}"-console.log 2> /dev/null|awk '{print $5}'|tail -1)
 	if [ -z "${currentbuild}" ]; then
 		fn_print_error_nl "Checking for update: factorio.com: Current build version not found"
 		fn_script_log_error "Checking for update: factorio.com: Current build version not found"
@@ -60,7 +60,7 @@ fn_update_factorio_currentbuild(){
 		command_stop.sh
 		exitbypass=1
 		command_start.sh
-		currentbuild=$(grep "Loading mod base" "${consolelogdir}"/"${servicename}"-console.log 2> /dev/null|awk '{print $5}')
+		currentbuild=$(grep "Loading mod base" "${consolelogdir}"/"${servicename}"-console.log 2> /dev/null|awk '{print $5}'|tail -1)
 		if [ -z "${currentbuild}" ]; then
 			fn_print_fail_nl "Checking for update: factorio.com: Current build version still not found"
 			fn_script_log_fatal "Checking for update: factorio.com: Current build version still not found"


### PR DESCRIPTION
Added Factorio Experimental build support. Needed to update the core_dl to extract the file properly, as well as added a new variable to switch from "stable" to "experimental". Updated version checking to return 1 line instead of more than 1, which would break the comparison as well.