### PR TITLE
Fixed and extended graceful shutdown

### DIFF
--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -228,6 +228,34 @@ fn_stop_graceful_mta(){
 	fn_stop_tmux
 }
 
+# Attempts graceful of source using rcon 'exit' command.
+fn_stop_graceful_terraria(){
+	fn_print_dots "Graceful: sending \"exit\""
+	fn_script_log_info "Graceful: sending \"exit\""
+	# sends exit
+	tmux send -t "${servicename}" exit ENTER > /dev/null 2>&1
+	# waits up to 30 seconds giving the server time to shutdown gracefuly
+	for seconds in {1..30}; do
+		check_status.sh
+		if [ "${status}" == "0" ]; then
+			fn_print_ok "Graceful: sending \"exit\": ${seconds}: "
+			fn_print_ok_eol_nl
+			fn_script_log_pass "Graceful: sending \"exit\": OK: ${seconds} seconds"
+			break
+		fi
+		sleep 1
+		fn_print_dots "Graceful: sending \"exit\": ${seconds}"
+	done
+	check_status.sh
+	if [ "${status}" != "0" ]; then
+		fn_print_error "Graceful: sending \"exit\": "
+		fn_print_fail_eol_nl
+		fn_script_log_error "Graceful: sending \"exit\": FAIL"
+	fi
+	sleep 1
+	fn_stop_tmux
+}
+
 fn_stop_graceful_select(){
 	if [ "${gamename}" == "7 Days To Die" ]; then
 		fn_stop_graceful_sdtd
@@ -241,6 +269,8 @@ fn_stop_graceful_select(){
 		fn_stop_graceful_minecraft
 	elif [ "${engine}" == "renderware" ]; then
 		fn_stop_graceful_mta
+	elif [ "${engine}" == "terraria" ]; then
+		fn_stop_graceful_terraria
 	else
 		fn_stop_tmux
 	fi

--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -259,18 +259,18 @@ fn_stop_graceful_terraria(){
 fn_stop_graceful_select(){
 	if [ "${gamename}" == "7 Days To Die" ]; then
 		fn_stop_graceful_sdtd
-	elif [ "${gamename}" == "Factorio" ]||[ "${gamename}" == "Minecraft" ]||[ "${gamename}" == "Multi Theft Auto" ]||[ "${engine}" == "unity3d" ]||[ "${engine}" == "unreal4" ]||[ "${engine}" == "unreal3" ]||[ "${engine}" == "unreal2" ]||[ "${engine}" == "unreal" ]||[ "${gamename}" == "Mumble" ]; then
-		fn_stop_graceful_ctrlc
-	elif  [ "${engine}" == "source" ]||[ "${engine}" == "quake" ]||[ "${engine}" == "idtech2" ]||[ "${engine}" == "idtech3" ]||[ "${engine}" == "idtech3_ql" ]||[ "${engine}" == "Just Cause 2" ]; then
-		fn_stop_graceful_quit
-	elif [ "${engine}" == "goldsource" ]; then
-		fn_stop_graceful_goldsource
+	elif [ "${gamename}" == "Terraria" ]; then
+		fn_stop_graceful_terraria
 	elif [ "${engine}" == "lwjgl2" ]; then
 		fn_stop_graceful_minecraft
 	elif [ "${engine}" == "renderware" ]; then
 		fn_stop_graceful_mta
-	elif [ "${engine}" == "terraria" ]; then
-		fn_stop_graceful_terraria
+	elif [ "${engine}" == "goldsource" ]; then
+		fn_stop_graceful_goldsource
+	elif [ "${gamename}" == "Factorio" ]||[ "${gamename}" == "Minecraft" ]||[ "${gamename}" == "Multi Theft Auto" ]||[ "${engine}" == "unity3d" ]||[ "${engine}" == "unreal4" ]||[ "${engine}" == "unreal3" ]||[ "${engine}" == "unreal2" ]||[ "${engine}" == "unreal" ]||[ "${gamename}" == "Mumble" ]; then
+		fn_stop_graceful_ctrlc
+	elif  [ "${engine}" == "source" ]||[ "${engine}" == "quake" ]||[ "${engine}" == "idtech2" ]||[ "${engine}" == "idtech3" ]||[ "${engine}" == "idtech3_ql" ]||[ "${engine}" == "Just Cause 2" ]; then
+		fn_stop_graceful_quit
 	else
 		fn_stop_tmux
 	fi

--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -172,7 +172,7 @@ fn_stop_graceful_sdtd(){
 	fn_stop_tmux
 }
 
-# Attempts graceful of source using rcon 'stop' command.
+# Attempts graceful of Minecraft using rcon 'stop' command.
 fn_stop_graceful_minecraft(){
 	fn_print_dots "Graceful: sending \"stop\""
 	fn_script_log_info "Graceful: sending \"stop\""
@@ -228,7 +228,7 @@ fn_stop_graceful_mta(){
 	fn_stop_tmux
 }
 
-# Attempts graceful of source using rcon 'exit' command.
+# Attempts graceful of Terraria using 'exit' console command.
 fn_stop_graceful_terraria(){
 	fn_print_dots "Graceful: sending \"exit\""
 	fn_script_log_info "Graceful: sending \"exit\""
@@ -261,13 +261,13 @@ fn_stop_graceful_select(){
 		fn_stop_graceful_sdtd
 	elif [ "${gamename}" == "Terraria" ]; then
 		fn_stop_graceful_terraria
-	elif [ "${engine}" == "lwjgl2" ]; then
+	elif [ "${gamename}" == "Minecraft" ]; then
 		fn_stop_graceful_minecraft
-	elif [ "${engine}" == "renderware" ]; then
+	elif [ "${gamename}" == "Multi Theft Auto" ]; then
 		fn_stop_graceful_mta
 	elif [ "${engine}" == "goldsource" ]; then
 		fn_stop_graceful_goldsource
-	elif [ "${gamename}" == "Factorio" ]||[ "${gamename}" == "Minecraft" ]||[ "${gamename}" == "Multi Theft Auto" ]||[ "${engine}" == "unity3d" ]||[ "${engine}" == "unreal4" ]||[ "${engine}" == "unreal3" ]||[ "${engine}" == "unreal2" ]||[ "${engine}" == "unreal" ]||[ "${gamename}" == "Mumble" ]; then
+	elif [ "${gamename}" == "Factorio" ]||[ "${engine}" == "unity3d" ]||[ "${engine}" == "unreal4" ]||[ "${engine}" == "unreal3" ]||[ "${engine}" == "unreal2" ]||[ "${engine}" == "unreal" ]||[ "${gamename}" == "Mumble" ]; then
 		fn_stop_graceful_ctrlc
 	elif  [ "${engine}" == "source" ]||[ "${engine}" == "quake" ]||[ "${engine}" == "idtech2" ]||[ "${engine}" == "idtech3" ]||[ "${engine}" == "idtech3_ql" ]||[ "${engine}" == "Just Cause 2" ]; then
 		fn_stop_graceful_quit


### PR DESCRIPTION
- added support for Terraria
- corrected check order to make proper graceful shutdown work again for MTA and Minecraft
- check for gamenames instead of engines (MTA, Minecraft)