### PR TITLE
Allows MTA to force update

### DIFF
--- a/lgsm/functions/core_getopt.sh
+++ b/lgsm/functions/core_getopt.sh
@@ -58,8 +58,8 @@ currentopt+=( "${cmd_update_linuxgsm[@]}" )
 # Exclude noupdate games here
 if [ "${gamename}" != "Battlefield: 1942" ]&&[ "${engine}" != "quake" ]&&[ "${engine}" != "idtech2" ]&&[ "${engine}" != "idtech3" ]&&[ "${engine}" != "iw2.0" ]&&[ "${engine}" != "iw3.0" ]; then
 	currentopt+=( "${cmd_update[@]}" )
-	# force update for SteamCMD only
-	if [ -n "${appid}" ]; then
+	# force update for SteamCMD only or MTA
+	if [ -n "${appid}" ] || [ "${gamename}" == "Multi Theft Auto" ]; then
 		currentopt+=( "${cmd_force_update[@]}" )
 	fi
 fi


### PR DESCRIPTION
MTA needs force update to update build revisions that aren't major revisions. We can't detect this ourselves through the logs but this is needed for bug fixes that don't cause a version bump. Note the "BUILD" number on this page:
https://linux.mtasa.com/

Although they did not bump the version, they did bug fixes to the build version. Force updates allows users to get this update.