### PR TITLE
Changed tar exclude to be the configured dir

### DIFF
--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -112,7 +112,7 @@ fn_backup_compression(){
 	sleep 2
 	fn_print_dots "Backup (${rootdirduexbackup}) ${backupname}.tar.gz, in progress..."
 	fn_script_log_info "backup ${rootdirduexbackup} ${backupname}.tar.gz, in progress"
-	tar -czf "${backupdir}/${backupname}.tar.gz" -C "${rootdir}" --exclude "backups" ./*
+	tar -czf "${backupdir}/${backupname}.tar.gz" -C "${rootdir}" --exclude "${backupdir}" ./*
 	local exitcode=$?
 	if [ ${exitcode} -ne 0 ]; then
 		fn_print_fail_eol


### PR DESCRIPTION
Updated the tar exclude to be the configured backup dir, instead of just a hardcoded "backup". This allows for people to change the backup directory location to still be in the game server dir, but in a custom directory. For me specifically it's an NFS mounted directory to backup to my NAS with the cloud backup then enabled on that dir.