### PR TITLE
Fixed PushBullet alerts duping strings, see #1524.

### DIFF
--- a/lgsm/functions/alert_pushbullet.sh
+++ b/lgsm/functions/alert_pushbullet.sh
@@ -24,12 +24,11 @@ fn_rawurlencode() {
      esac
      encoded+="${o}"
   done
-  echo "${encoded}"    # You can either set a return variable (FASTER)
-  REPLY="${encoded}"   #+or echo the result (EASIER)... or both... :p
+  echo "${encoded}"    # If echo is faster, let's just echo it.
 }
 
-pbalertbody=$(fn_rawurlencode "${alertbody}"; echo ${REPLY})
-pbalertsubject=$(fn_rawurlencode "${alertsubject}"; echo ${REPLY})
+pbalertbody=$(fn_rawurlencode "${alertbody}")
+pbalertsubject=$(fn_rawurlencode "${alertsubject}")
 
 fn_print_dots "Sending Pushbullet alert"
 sleep 1


### PR DESCRIPTION
As outlined in GameServerManagers/LinuxGSM#1524, the PushBullet alert script was somehow printing the same text twice in a single field. By removing the reply variable from both the fn_rawurlencode() function and from the variables used not 3 lines down, we produce the intended alert.

I made a minor error in a comment where I mislabeled echo as being faster, however the script functions as intended.