### PR TITLE
Symlinking the SteamCMD dir for ARK

### DIFF
--- a/lgsm/functions/command_install.sh
+++ b/lgsm/functions/command_install.sh
@@ -39,6 +39,8 @@ elif [ "${gamename}" == "TeamSpeak 3" ]; then
 	install_ts3db.sh
 elif [ "${gamename}" == "Multi Theft Auto" ]; then
 	command_install_resources_mta.sh
+elif [ "${gamename}" == "ARK: Survival Evolved" ]; then
+	ln -s "${steamcmddir}" "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux"
 fi
 
 fix.sh


### PR DESCRIPTION
Symlinking the SteamCMD directory into the correct ARK directory so that the mods auto-management will work fine. See http://ark.gamepedia.com/244.3 for the CLI option and Game.ini configuration settings.