### PR TITLE
Syntax error in UT3 default config

### DIFF
--- a/lgsm/config-default/config-lgsm/ut3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut3server/_default.cfg
@@ -26,7 +26,7 @@ allowjoininprogress="true"
 ## Server Start Command | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters#additional-parameters
 # Edit with care | List of game types and mutators : http://wiki.unrealadmin.org/FAQ:UT3
 fn_parms(){
-parms="server ${defaultmap}?Game=${game}?bIsDedicated=${isdedicated}?bIsLanMatch=${islanmatch}?bUsesStats=${usesstats}?bShouldAdvertise=${shouldadvertise}?PureServer=${pureserver}?bAllowJoinInProgress=${allowjoininprogress}?MaxPlayers=${maxplayers}?Mutator=${mutators} -port=${port} -queryport=${queryport} -multihome=${ip} -nohomedir -unattended -log=${gamelog} -ini=${servercfgfullpath}""
+parms="server ${defaultmap}?Game=${game}?bIsDedicated=${isdedicated}?bIsLanMatch=${islanmatch}?bUsesStats=${usesstats}?bShouldAdvertise=${shouldadvertise}?PureServer=${pureserver}?bAllowJoinInProgress=${allowjoininprogress}?MaxPlayers=${maxplayers}?Mutator=${mutators} -port=${port} -queryport=${queryport} -multihome=${ip} -nohomedir -unattended -log=${gamelog} -ini=${servercfgfullpath}"
 }
 
 #### LinuxGSM Settings ####


### PR DESCRIPTION
Duplicate quote in UT3 default config caused server install to fail. Can be merged on code review.