### PR TITLE
Pull request for feature/issue-1385 branch

### DIFF
--- a/lgsm/functions/check_ip.sh
+++ b/lgsm/functions/check_ip.sh
@@ -19,9 +19,10 @@ if [ "${gamename}" != "TeamSpeak 3" ]&&[ "${gamename}" != "Mumble" ]&&[ "${travi
 	info_config.sh
 	if [ "${ip}" == "0.0.0.0" ]||[ "${ip}" == "" ]; then
 		if [ "${getipwc}" -ge "2" ]; then
-			fn_print_dots "Check IP"
+		        multiple_ip=1
+		        fn_print_dots "Check IP"
 			sleep 1
-			fn_print_fail "Check IP: Multiple active network interfaces found."
+			fn_print_warn "Check IP: Multiple active network interfaces found."
 			sleep 1
 			echo -en "\n"
 			if [ "${ipsetinconfig}" == "1" ]; then

--- a/lgsm/functions/check_ip.sh
+++ b/lgsm/functions/check_ip.sh
@@ -22,7 +22,12 @@ if [ "${gamename}" != "TeamSpeak 3" ]&&[ "${gamename}" != "Mumble" ]&&[ "${travi
 		        multiple_ip=1
 		        fn_print_dots "Check IP"
 			sleep 1
-			fn_print_warn "Check IP: Multiple active network interfaces found."
+			command_arg=$(ps -o command $$ | tail -n +2 | cut -d' ' -f3)
+			if [[ "${command_arg}" = "details" ]] || [[ "${command_arg}" = "dt" ]] ; then
+			    fn_print_warn "Check IP: Multiple active network interfaces found."
+			else
+			    fn_print_fail "Check IP: Multiple active network interfaces found."
+			fi
 			sleep 1
 			echo -en "\n"
 			if [ "${ipsetinconfig}" == "1" ]; then
@@ -46,7 +51,9 @@ if [ "${gamename}" != "TeamSpeak 3" ]&&[ "${gamename}" != "Mumble" ]&&[ "${travi
 				fn_script_log_fatal "Manually specify the IP you want to use within: ${configdirserver}."
 			fi
 			fn_script_log_fatal "https://gameservermanagers.com/network-interfaces\n"
-			core_exit.sh
+			if [[ "${command_arg}" != "details" ]] && [[ "${command_arg}" != "dt" ]] ; then
+			    core_exit.sh
+			fi
 		else
 			ip=${getip}
 		fi

--- a/lgsm/functions/command_details.sh
+++ b/lgsm/functions/command_details.sh
@@ -116,8 +116,12 @@ fn_details_gameserver(){
 		fi
 
 		# Server ip
-		echo -e "${blue}Server IP:\t${default}${ip}:${port}"
-
+		if [ ${multiple_ip} == 1 ]; then
+		    echo -e "${blue}Server IP:\t${default}NOT SET"
+		else
+		    echo -e "${blue}Server IP:\t${default}${ip}:${port}"
+		fi
+		    
 		# Server password
 		if [ -n "${serverpassword}" ]; then
 			echo -e "${blue}Server password:\t${default}${serverpassword}"


### PR DESCRIPTION
Pull request submitted to address https://github.com/GameServerManagers/LinuxGSM/issues/1385

Changes made:
check_ip.sh:
- Added a flag (multiple_ip) that indicates multiple IPs detected
- Parsed ps output about the current process to determine the argument passed to the main game server script. If the argument was "details" or "dt" then fn_print_warn is called, else fn_print_fail is called. This has also been adapted to work for "dt"
- If multiple IPs detected and main game server script's argument is NOT "details" or "dt," core_exit.sh will run from check_ip.sh.

command_details.sh:
- Wrapped code outputting IP details in an if statement. If mulitple_ip=1 , output "NOT SET". Otherwise the IP and port will output as normal