### PR TITLE
Backup exclusion testing

### DIFF
--- a/lgsm/config-default/config-lgsm/arkserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arkserver/_default.cfg
@@ -88,3 +88,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"	

--- a/lgsm/config-default/config-lgsm/arma3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arma3server/_default.cfg
@@ -106,3 +106,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/backupexclusion-template.cfg
+++ b/lgsm/config-default/config-lgsm/backupexclusion-template.cfg
@@ -1,0 +1,8 @@
+## Default exclusion for "backups" directory
+# Do not change
+backups
+
+## List custom exclusions here
+# The exclusions can be folder names or files names
+# Wildcards are accepted
+# Note: Watch out for white spaces at the end of each line

--- a/lgsm/config-default/config-lgsm/bb2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bb2server/_default.cfg
@@ -97,3 +97,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/bf1942server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bf1942server/_default.cfg
@@ -76,3 +76,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/bmdmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bmdmserver/_default.cfg
@@ -97,3 +97,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/boserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/boserver/_default.cfg
@@ -87,3 +87,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/bsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bsserver/_default.cfg
@@ -96,3 +96,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/ccserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ccserver/_default.cfg
@@ -92,3 +92,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/cod2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cod2server/_default.cfg
@@ -76,3 +76,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/cod4server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cod4server/_default.cfg
@@ -76,3 +76,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/codserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/codserver/_default.cfg
@@ -76,3 +76,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/coduoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/coduoserver/_default.cfg
@@ -76,3 +76,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/codwawserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/codwawserver/_default.cfg
@@ -76,3 +76,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/coserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/coserver/_default.cfg
@@ -120,3 +120,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/csczserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csczserver/_default.cfg
@@ -92,3 +92,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -112,3 +112,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/csserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csserver/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${scriptlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/cssserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cssserver/_default.cfg
@@ -94,3 +94,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/dabserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dabserver/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/dmcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dmcserver/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/dodserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dodserver/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/dodsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dodsserver/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/doiserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/doiserver/_default.cfg
@@ -91,3 +91,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/dstserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dstserver/_default.cfg
@@ -99,3 +99,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/emserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/emserver/_default.cfg
@@ -94,3 +94,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/fctrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/fctrserver/_default.cfg
@@ -79,3 +79,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/fofserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/fofserver/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/gesserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/gesserver/_default.cfg
@@ -88,3 +88,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/gmodserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/gmodserver/_default.cfg
@@ -105,3 +105,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/hldmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hldmserver/_default.cfg
@@ -88,3 +88,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/hldmsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hldmsserver/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/hwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hwserver/_default.cfg
@@ -105,3 +105,5 @@ gamelogdate="${gamelogdir}/${servicename}-game-$(date '+%Y-%m-%d-%H:%M:%S').log"
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
 
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/insserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/insserver/_default.cfg
@@ -96,3 +96,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/jc2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jc2server/_default.cfg
@@ -81,3 +81,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/kfserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/kfserver/_default.cfg
@@ -95,3 +95,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/l4d2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/l4d2server/_default.cfg
@@ -88,3 +88,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/l4dserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/l4dserver/_default.cfg
@@ -88,3 +88,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/mcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mcserver/_default.cfg
@@ -75,3 +75,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/mtaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mtaserver/_default.cfg
@@ -71,3 +71,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/mumbleserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mumbleserver/_default.cfg
@@ -73,3 +73,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
@@ -94,3 +94,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/ns2cserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ns2cserver/_default.cfg
@@ -99,3 +99,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/ns2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ns2server/_default.cfg
@@ -99,3 +99,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/opforserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/opforserver/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/pcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pcserver/_default.cfg
@@ -82,3 +82,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/pvkiiserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pvkiiserver/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/pzserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pzserver/_default.cfg
@@ -84,3 +84,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/q2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/q2server/_default.cfg
@@ -75,3 +75,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/q3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/q3server/_default.cfg
@@ -75,3 +75,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/qlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qlserver/_default.cfg
@@ -87,3 +87,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/qwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qwserver/_default.cfg
@@ -74,3 +74,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/ricochetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ricochetserver/_default.cfg
@@ -108,3 +108,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/roserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/roserver/_default.cfg
@@ -93,3 +93,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
 gamelogdate="${gamelogdir}/${servicename}-game-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/rustserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rustserver/_default.cfg
@@ -108,3 +108,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
 gamelogdate="${gamelogdir}/${servicename}-game-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/sbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sbserver/_default.cfg
@@ -88,3 +88,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/ss3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ss3server/_default.cfg
@@ -87,3 +87,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
 gamelogdate="${gamelogdir}/${servicename}-game-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/svenserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/svenserver/_default.cfg
@@ -88,3 +88,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/terrariaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/terrariaserver/_default.cfg
@@ -88,3 +88,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/tf2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tf2server/_default.cfg
@@ -94,3 +94,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/tfcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tfcserver/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/ts3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ts3server/_default.cfg
@@ -66,3 +66,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/tuserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tuserver/_default.cfg
@@ -86,3 +86,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/twserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/twserver/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/ut2k4server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut2k4server/_default.cfg
@@ -77,3 +77,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
 gamelogdate="${gamelogdir}/${servicename}-game-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/ut3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut3server/_default.cfg
@@ -89,3 +89,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
 gamelogdate="${gamelogdir}/${servicename}-game-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/ut99server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut99server/_default.cfg
@@ -75,3 +75,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/utserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/utserver/_default.cfg
@@ -77,3 +77,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/config-default/config-lgsm/wetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wetserver/_default.cfg
@@ -70,3 +70,6 @@ emaillog="${lgsmlogdir}/${servicename}-email.log"
 ## Logs Naming
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
+
+## Backup exclusions
+exclusionfile="${configdir}/${gameservername}/backupexclusion.cfg"

--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -189,7 +189,7 @@ fn_backup_start_server(){
 
 # Send the backup file off to Dropbox
 fn_backup_cloud(){
-	if [ -f "${backupdir}/${backupname}.tar.gz" ]
+	if [ -f "${backupdir}/${backupname}.tar.gz" ]; then
 		fn_print_ok_nl "Sending ${backupname} to Dropbox"
 		fn_script_log_info "Sending ${backupname} to Dropbox"
 		sleep 1

--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -190,10 +190,21 @@ fn_backup_start_server(){
 # Send the backup file off to Dropbox
 fn_backup_cloud(){
 	if [ -f "${backupdir}/${backupname}.tar.gz" ]; then
-		fn_print_ok_nl "Sending ${backupname} to Dropbox"
-		fn_script_log_info "Sending ${backupname} to Dropbox"
+		fn_print_ok_nl "Sending ${backupname}.tar.gz to Dropbox"
+		fn_script_log_info "Sending ${backupname}.tar.gz to Dropbox"
 		sleep 1
-		"~/Dropbox-Uploader-master/dropbox_uploader.sh" -p upload "${backupdir}/${backupname}.tar.gz" "${backupname}.tar.gz"
+		"~/Dropbox-Uploader-master/dropbox_uploader.sh" upload "${backupdir}/${backupname}.tar.gz" "${backupname}.tar.gz"
+		local exitcode=$?
+		if [ "${exitcode}" -ne 0 ]; then
+			sleep 1
+			fn_print_warn_nl "Upload to Dropbox failed. Please investigate."
+			fn_script_log_warn "Upload to Dropbox failed. Please investigate."
+		else
+			sleep 1
+			fn_print_ok_nl "Upload to Dropbox completed successfully."
+			fn_script_log_info "Upload to Dropbox completed successfully."
+		fi
+		sleep 1
 	fi
 }
 

--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -187,6 +187,16 @@ fn_backup_start_server(){
 	fi
 }
 
+# Send the backup file off to Dropbox
+fn_backup_cloud(){
+	if [ -f "${backupdir}/${backupname}.tar.gz" ]
+		fn_print_ok_nl "Sending ${backupname} to Dropbox"
+		fn_script_log_info "Sending ${backupname} to Dropbox"
+		sleep 1
+		"~/Dropbox-Uploader-master/dropbox_uploader.sh" upload "${backupdir}/${backupname}.tar.gz"
+	fi
+}
+
 # Run functions
 fn_backup_check_lockfile
 fn_backup_create_lockfile
@@ -196,4 +206,5 @@ fn_backup_dir
 fn_backup_compression
 fn_backup_prune
 fn_backup_start_server
+fn_backup_cloud
 core_exit.sh

--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -112,7 +112,7 @@ fn_backup_compression(){
 	sleep 2
 	fn_print_dots "Backup (${rootdirduexbackup}) ${backupname}.tar.gz, in progress..."
 	fn_script_log_info "backup ${rootdirduexbackup} ${backupname}.tar.gz, in progress"
-	tar -czf "${backupdir}/${backupname}.tar.gz" -C "${rootdir}" --exclude "${backupdir}" ./*
+	tar -czf "${backupdir}/${backupname}.tar.gz" -C "${rootdir}" -X "${exclusionfile}" ./*
 	local exitcode=$?
 	if [ ${exitcode} -ne 0 ]; then
 		fn_print_fail_eol

--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -193,7 +193,7 @@ fn_backup_cloud(){
 		fn_print_ok_nl "Sending ${backupname} to Dropbox"
 		fn_script_log_info "Sending ${backupname} to Dropbox"
 		sleep 1
-		"~/Dropbox-Uploader-master/dropbox_uploader.sh" upload "${backupdir}/${backupname}.tar.gz"
+		"~/Dropbox-Uploader-master/dropbox_uploader.sh" -p upload "${backupdir}/${backupname}.tar.gz" "${backupname}.tar.gz"
 	fi
 }
 

--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -193,7 +193,7 @@ fn_backup_cloud(){
 		fn_print_ok_nl "Sending ${backupname}.tar.gz to Dropbox"
 		fn_script_log_info "Sending ${backupname}.tar.gz to Dropbox"
 		sleep 1
-		"~/Dropbox-Uploader-master/dropbox_uploader.sh" upload "${backupdir}/${backupname}.tar.gz" "${backupname}.tar.gz"
+		~/Dropbox-Uploader-master/dropbox_uploader.sh upload "${backupdir}/${backupname}.tar.gz" "${backupname}.tar.gz"
 		local exitcode=$?
 		if [ "${exitcode}" -ne 0 ]; then
 			sleep 1

--- a/lgsm/functions/core_messages.sh
+++ b/lgsm/functions/core_messages.sh
@@ -29,9 +29,9 @@ fi
 fn_script_log(){
 	if [ -d "${lgsmlogdir}" ]; then
 		if [ -n "${commandname}" ]; then
-			echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: ${commandname}: ${1}" >> "${lgsmlog}"
+			echo -e "$(date '+%b %d %H:%M:%S.%3N') ${servicename}: ${commandname}: ${1}" >> "${lgsmlog}"
 		else
-			echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: ${1}" >> "${lgsmlog}"
+			echo -e "$(date '+%b %d %H:%M:%S.%3N') ${servicename}: ${1}" >> "${lgsmlog}"
 		fi
 	fi
 }
@@ -40,9 +40,9 @@ fn_script_log(){
 fn_script_log_pass(){
 	if [ -d "${lgsmlogdir}" ]; then
 		if [ -n "${commandname}" ]; then
-			echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: ${commandname}: PASS: ${1}" >> "${lgsmlog}"
+			echo -e "$(date '+%b %d %H:%M:%S.%3N') ${servicename}: ${commandname}: PASS: ${1}" >> "${lgsmlog}"
 		else
-			echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: PASS: ${1}" >> "${lgsmlog}"
+			echo -e "$(date '+%b %d %H:%M:%S.%3N') ${servicename}: PASS: ${1}" >> "${lgsmlog}"
 		fi
 	fi
 	exitcode=0
@@ -52,9 +52,9 @@ fn_script_log_pass(){
 fn_script_log_fatal(){
 	if [ -d "${lgsmlogdir}" ]; then
 		if [ -n "${commandname}" ]; then
-			echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: ${commandname}: FATAL: ${1}" >> "${lgsmlog}"
+			echo -e "$(date '+%b %d %H:%M:%S.%3N') ${servicename}: ${commandname}: FATAL: ${1}" >> "${lgsmlog}"
 		else
-			echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: FATAL: ${1}" >> "${lgsmlog}"
+			echo -e "$(date '+%b %d %H:%M:%S.%3N') ${servicename}: FATAL: ${1}" >> "${lgsmlog}"
 		fi
 	fi
 	exitcode=1
@@ -64,9 +64,9 @@ fn_script_log_fatal(){
 fn_script_log_error(){
 	if [ -d "${lgsmlogdir}" ]; then
 		if [ -n "${commandname}" ]; then
-			echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: ${commandname}: ERROR: ${1}" >> "${lgsmlog}"
+			echo -e "$(date '+%b %d %H:%M:%S.%3N') ${servicename}: ${commandname}: ERROR: ${1}" >> "${lgsmlog}"
 		else
-			echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: ERROR: ${1}" >> "${lgsmlog}"
+			echo -e "$(date '+%b %d %H:%M:%S.%3N') ${servicename}: ERROR: ${1}" >> "${lgsmlog}"
 		fi
 	fi
 	exitcode=2
@@ -76,9 +76,9 @@ fn_script_log_error(){
 fn_script_log_warn(){
 	if [ -d "${lgsmlogdir}" ]; then
 		if [ -n "${commandname}" ]; then
-			echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: ${commandname}: WARN: ${1}" >> "${lgsmlog}"
+			echo -e "$(date '+%b %d %H:%M:%S.%3N') ${servicename}: ${commandname}: WARN: ${1}" >> "${lgsmlog}"
 		else
-			echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: WARN: ${1}" >> "${lgsmlog}"
+			echo -e "$(date '+%b %d %H:%M:%S.%3N') ${servicename}: WARN: ${1}" >> "${lgsmlog}"
 		fi
 	fi
 	exitcode=3
@@ -88,9 +88,9 @@ fn_script_log_warn(){
 fn_script_log_info(){
 	if [ -d "${lgsmlogdir}" ]; then
 		if [ -n "${commandname}" ]; then
-			echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: ${commandname}: INFO: ${1}" >> "${lgsmlog}"
+			echo -e "$(date '+%b %d %H:%M:%S.%3N') ${servicename}: ${commandname}: INFO: ${1}" >> "${lgsmlog}"
 		else
-			echo -e "$(date '+%b %d %H:%M:%S') ${servicename}: INFO: ${1}" >> "${lgsmlog}"
+			echo -e "$(date '+%b %d %H:%M:%S.%3N') ${servicename}: INFO: ${1}" >> "${lgsmlog}"
 		fi
 	fi
 }

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -42,9 +42,9 @@ configdirdefault="${lgsmdir}/config-default"
 ## GitHub Branch Select
 # Allows for the use of different function files
 # from a different repo and/or branch.
-githubuser="jimwald1221"
-githubrepo="LinuxGSM-Testing"
-githubbranch="backup-testing"
+githubuser="GameServerManagers"
+githubrepo="LinuxGSM"
+githubbranch="master"
 
 # Core Function that is required first
 core_functions.sh(){

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -42,9 +42,9 @@ configdirdefault="${lgsmdir}/config-default"
 ## GitHub Branch Select
 # Allows for the use of different function files
 # from a different repo and/or branch.
-githubuser="GameServerManagers"
-githubrepo="LinuxGSM"
-githubbranch="master"
+githubuser="jimwald1221"
+githubrepo="LinuxGSM-Testing"
+githubbranch="backup-testing"
 
 # Core Function that is required first
 core_functions.sh(){

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -366,6 +366,10 @@ else
 	else
 		source "${configdirserver}/${servicename}.cfg"
 	fi
+	# Load the backupexclusion.cfg config. If missing download it
+	if [ ! -f "${configdirserver}/backupexclusion.cfg" ]; then
+		fn_fetch_config "lgsm/config-default/config-lgsm" "backupexclusion-template.cfg" "${configdirserver}" "backupexclusion.cfg" "${chmodx}" "nochmodx" "norun" "noforcedl" "nomd5"
+	fi
 	# Load the linuxgsm.sh in to tmpdir. If missing download it
 	if [ ! -f "${tmpdir}/linuxgsm.sh" ]; then
 		fn_fetch_file_github "" "linuxgsm.sh" "${tmpdir}" "chmodx" "norun" "noforcedl" "nomd5"


### PR DESCRIPTION
I've reworked the backup command to use a flat file that is used for file and folder exclusions in an attempt to allow admins to exclude files or folders from their backups. The idea being they can exclude game files that will be replaced by repairing the game server and it helps keep their backups smaller.

I've also added the necessary exclude file variable and a check for the "backupexclude.cfg" in the same fashion as "common.cfg" and "instance.cfg" so it should fold into current installations without issue.