### PR TITLE
Fix ARK dedicated server minimum RAM requirements

### DIFF
--- a/lgsm/functions/check_system_requirements.sh
+++ b/lgsm/functions/check_system_requirements.sh
@@ -14,7 +14,7 @@ info_distro.sh
 
 if [ "${gamename}" == "ARK: Survival Evolved" ]; then
 	ramrequirementmb="4000"
-	ramrequirementgb="1"
+	ramrequirementgb="4"
 elif [ "${gamename}" == "ARMA 3" ]; then
 	ramrequirementmb="1000"
 	ramrequirementgb="1"


### PR DESCRIPTION
Minor typo fix, ARK server checks for 4GB but warning about 1GB.