### PR TITLE
Minor improvements

### DIFF
--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -11,11 +11,12 @@
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 # https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive_Dedicated_Servers#Starting_the_Server
 # [Game Modes]			gametype	gamemode
-# Arms Race				1			0
 # Classic Casual		0			0
 # Classic Competitive	0			1
+# Arms Race				1			0
 # Demolition			1			1
 # Deathmatch			1			2
+# Custom				3			0
 gametype="0"
 gamemode="0"
 mapgroup="mg_active"

--- a/lgsm/config-default/config-lgsm/zpsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/zpsserver/_default.cfg
@@ -16,14 +16,9 @@ sourcetvport="27020"
 defaultmap="zps_deadend"
 maxplayers="20"
 
-## Optional: Game Server Login Token
-# GSLT can be used for running a public server.
-# More info: https://gameservermanagers.com/gslt
-gslt=""
-
 ## Server Start Command | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters#additional-parameters
 fn_parms(){
-parms="-game zps -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} +sv_setsteamaccount ${gslt} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
+parms="-game zps -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
 }
 
 #### LinuxGSM Settings ####

--- a/lgsm/functions/alert_mailgun.sh
+++ b/lgsm/functions/alert_mailgun.sh
@@ -11,7 +11,7 @@ local function_selfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
 fn_print_dots "Sending Email alert: Mailgun: ${email}"
 sleep 0.5
 
-mailgunsend=$(curl -s --user "api:${mailguntoken}" \
+mailgunsend=$(${curlpath} -s --user "api:${mailguntoken}" \
 -F from="LinuxGSM <${mailgunemailfrom}>" \
 -F to="LinuxGSM Admin <${mailgunemail}>" \
 -F subject="${alertemoji} ${alertsubject} ${alertemoji}" \

--- a/lgsm/functions/fix_csgo.sh
+++ b/lgsm/functions/fix_csgo.sh
@@ -20,7 +20,7 @@ fi
 if [ -f "${systemdir}/botprofile.db" ] && grep "^\s*Rank" "${systemdir}/botprofile.db" > /dev/null 2>&1; then
 	fixname="botprofile.db"
 	fn_fix_msg_start
-	sed -i 's/\s*Rank/\t\/\/Rank/g' "${systemdir}/botprofile.db" > /dev/null 2>&1
+	sed -i 's/^\s*Rank/\t\/\/Rank/g' "${systemdir}/botprofile.db" > /dev/null 2>&1
 	fn_fix_msg_end
 fi
 

--- a/lgsm/functions/fix_csgo.sh
+++ b/lgsm/functions/fix_csgo.sh
@@ -17,19 +17,19 @@ if [ ! -f "${serverfiles}/steam_appid.txt" ]; then
 fi
 
 # Fixes: Error parsing BotProfile.db - unknown attribute 'Rank'".
-if ! grep -q "//Rank" "${systemdir}/botprofile.db" > /dev/null 2>&1; then
+if [ -f "${systemdir}/botprofile.db" ] && grep "^\s*Rank" "${systemdir}/botprofile.db" > /dev/null 2>&1; then
 	fixname="botprofile.db"
 	fn_fix_msg_start
-	sed -i 's/\tRank/\t\/\/Rank/g' "${systemdir}/botprofile.db" > /dev/null 2>&1
+	sed -i 's/\s*Rank/\t\/\/Rank/g' "${systemdir}/botprofile.db" > /dev/null 2>&1
 	fn_fix_msg_end
 fi
 
-# Fixes: Unknown command "cl_bobamt_vert".
-if ! grep -q "//exec default" "${servercfgdir}/valve.rc" > /dev/null 2>&1 || ! grep -q "//exec joystick" "${servercfgdir}/valve.rc" > /dev/null 2>&1; then
+# Fixes: Unknown command "cl_bobamt_vert" and exec: couldn't exec joystick.cfg.
+if [ -f "${servercfgdir}/valve.rc" ] && grep -E '^\s*exec\s*(default|joystick)\.cfg' "${servercfgdir}/valve.rc" > /dev/null 2>&1; then
 	fixname="valve.rc"
 	fn_fix_msg_start
-	sed -i 's/exec default.cfg/\/\/exec default.cfg/g' "${servercfgdir}/valve.rc" > /dev/null 2>&1
-	sed -i 's/exec joystick.cfg/\/\/exec joystick.cfg/g' "${servercfgdir}/valve.rc" > /dev/null 2>&1
+	sed -i 's/^\s*exec\s*default.cfg/\/\/exec default.cfg/g' "${servercfgdir}/valve.rc" > /dev/null 2>&1
+	sed -i 's/^\s*exec\s*joystick.cfg/\/\/exec joystick.cfg/g' "${servercfgdir}/valve.rc" > /dev/null 2>&1
 	fn_fix_msg_end
 fi
 

--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -136,5 +136,5 @@ fi
 
 # External IP address
 if [ -z "${extip}" ];then
-	extip=$(curl -m 3 ifconfig.co 2>/dev/null)
+	extip=$(${curlpath} -m 3 ifconfig.co 2>/dev/null)
 fi

--- a/lgsm/functions/update_factorio.sh
+++ b/lgsm/functions/update_factorio.sh
@@ -76,7 +76,7 @@ fn_update_factorio_arch(){
 
 fn_update_factorio_availablebuild(){
 	# Gets latest build info.
-	availablebuild=$(curl -s https://www.factorio.com/download-headless/"${branch}" | grep 'headless/linux64' | head -n 1 | grep -oP '(?<=get-download/).*?(?=/)')
+	availablebuild=$(${curlpath} -s https://www.factorio.com/download-headless/"${branch}" | grep 'headless/linux64' | head -n 1 | grep -oP '(?<=get-download/).*?(?=/)')
 	sleep 1
 
 	# Checks if availablebuild variable has been set

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -229,9 +229,9 @@ fn_install_getopt(){
 	echo "https://gameservermanagers.com"
 	echo -e ""
 	echo -e "Commands"
-	echo -e "install\t\t|Select server to install."
-	echo -e "servername\t|e.g $0 csgoserver. Enter name of server/game to install."
-	echo -e "list\t\t|List all servers available for install."
+	echo -e "install\t\t| Select server to install."
+	echo -e "servername\t| e.g $0 csgoserver. Enter name of server/game to install."
+	echo -e "list\t\t| List all servers available for install."
 	exit
 }
 

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -229,9 +229,9 @@ fn_install_getopt(){
 	echo "https://gameservermanagers.com"
 	echo -e ""
 	echo -e "Commands"
-	echo -e "install |Select server to install."
-	echo -e "servername |e.g $0 csgoserver. Enter the required servername will install it."
-	echo -e "list |List all servers available for install."
+	echo -e "install\t\t|Select server to install."
+	echo -e "servername\t|e.g $0 csgoserver. Enter name of server/game to install."
+	echo -e "list\t\t|List all servers available for install."
 	exit
 }
 
@@ -307,8 +307,10 @@ if [ "${shortname}" == "core" ]; then
 		fi
 	elif [ -n "${userinput}" ]; then
 		fn_server_info
-		if [ "${userinput}" == "${gameservername}" ]; then
+		if [ "${userinput}" == "${gameservername}" ]||[ "${userinput}" == "${gamename}" ]||[ "${userinput}" == "${shortname}" ]; then
 			fn_install_file
+		else
+			echo "[ FAIL ] unknown game server"
 		fi
 	else
 		fn_install_getopt


### PR DESCRIPTION
- added info about custom game mode to the info table (Fixes #1602)
- reordered that table by game type category
- removed GSLT from Zombie Panic! Source because it's not supported
- allow passing of game-, short-, server names as script parameter for installing the specified server
- added message when the given game-, short-, server name is unknown
- changed look of linuxgsm.sh command display
- changed the rest of direct curl calls to ${curlpath}
- improved CS:GO fixes (checks, ..) (Probably fixes #1095)