### PR TITLE
Fixes backup backuping itself

### DIFF
--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -112,7 +112,8 @@ fn_backup_compression(){
 	sleep 2
 	fn_print_dots "Backup (${rootdirduexbackup}) ${backupname}.tar.gz, in progress..."
 	fn_script_log_info "backup ${rootdirduexbackup} ${backupname}.tar.gz, in progress"
-	tar -czf "${backupdir}/${backupname}.tar.gz" -C "${rootdir}" --exclude "${backupdir}" ./*
+	excludedir=$(realpath --relative-to="${rootdir}" "${backupdir}")
+	tar -czf "${backupdir}/${backupname}.tar.gz" -C "${rootdir}" --exclude "${excludedir}" ./*
 	local exitcode=$?
 	if [ ${exitcode} -ne 0 ]; then
 		fn_print_fail_eol


### PR DESCRIPTION
This issue has caused enough trouble. Time to annihilate the issue.
Thanks @marvinlehmann for the fix
#1563 

Sample output:
```
arkserver@gaben:~$ ./arkserver b
[  OK  ] Backup arkserver: Backup starting
        * Previous backup was created less than 1 day ago, total size 2.7G
[ WARN ] Backup arkserver: arkserver is currently running
        * Although unlikely; creating a backup while arkserver is running might corrupt the backup.
[  OK  ] Backup arkserver: Completed: arkserver-2017-10-29-163529.tar.gz, total size 2.7G

arkserver@gaben:~$ du -sh lgsm/backup/*
2.7G    lgsm/backup/arkserver-2017-10-29-155940.tar.gz
2.7G    lgsm/backup/arkserver-2017-10-29-163529.tar.gz
```
