### PR TITLE
Ensures conditionalseed mechanics to work 

### DIFF
--- a/lgsm/config-default/config-lgsm/rustserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rustserver/_default.cfg
@@ -26,9 +26,6 @@ tickrate="30" # default 30; range : 15 to 100
 
 ## Server Start Command | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters#additional-parameters
 fn_parms(){
-parms="-batchmode +server.ip ${ip} +server.port ${port} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${servicename}\" ${conditionalseed} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile \"${gamelogdate}\""
-}
-
 # Specific to Rust
 if [ -n "${seed}" ]; then
 	# If set, then add to start parms
@@ -37,6 +34,8 @@ else
 	# Keep randomness of the number if not set
 	conditionalseed=""
 fi
+parms="-batchmode +server.ip ${ip} +server.port ${port} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${servicename}\" ${conditionalseed} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile \"${gamelogdate}\""
+}
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
Seems like conditionalseed variable (allowing to have seed unset) didn't work as expected with new lgsm updates. So I moved the function to a place where we're sure it's executed: inside fn_parms

Fixes #1691