### PR TITLE
Removed  variable from Factorio headless server request as it current…

### DIFF
--- a/lgsm/functions/update_factorio.sh
+++ b/lgsm/functions/update_factorio.sh
@@ -76,7 +76,7 @@ fn_update_factorio_arch(){
 
 fn_update_factorio_availablebuild(){
 	# Gets latest build info.
-	availablebuild=$(curl -s https://www.factorio.com/download-headless/"${branch}" | grep 'headless/linux64' | head -n 1 | grep -oP '(?<=get-download/).*?(?=/)')
+	availablebuild=$(curl -s https://www.factorio.com/download-headless | grep 'headless/linux64' | head -n 1 | grep -oP '(?<=get-download/).*?(?=/)')
 	sleep 1
 
 	# Checks if availablebuild variable has been set


### PR DESCRIPTION
Factorio Install issue #1717
 
Removing `$branch` variable from Factorio URL request fixes the "Update failed" message in install.