### PR TITLE
relative path using readlink instead of realpath

### DIFF
--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -210,19 +210,19 @@ fn_backup_relpath() {
 
 	# Compare the leading entries of each array.  These common elements will be clipped off
 	# for the relative path output.
-  	for ((base=0; $base<${#rdirtoks[@]}; base++))
+  	for ((base=0; base<${#rdirtoks[@]}; base++))
   	do
       		[[ "${rdirtoks[$base]}" != "${bdirtoks[$base]}" ]] && break
   	done
 
 	# Next, climb out of the remaining rootdir location with updir references...
-  	for ((x=${base};$x<${#rdirtoks[@]};x++))
+  	for ((x=base;x<${#rdirtoks[@]};x++))
   	do
       		echo -n "../"
   	done
 
 	# Climb down the remaining components of the backupdir location.
-  	for ((x=${base};$x<$(( ${#bdirtoks[@]} - 1 ));x++))
+  	for ((x=base;x<$(( ${#bdirtoks[@]} - 1 ));x++))
   	do
       		echo -n "${bdirtoks[$x]}/"
   	done
@@ -231,7 +231,7 @@ fn_backup_relpath() {
 	# traverse down, just add a newline.  Otherwise at this point, there is
 	# one remaining directory component in the backupdir to navigate.
   	if (( "$base" < "${#bdirtoks[@]}" )) ; then
-      		echo ${bdirtoks[ $(( ${#bdirtoks[@]} - 1)) ]}
+      		echo "${bdirtoks[ $(( ${#bdirtoks[@]} - 1)) ]}"
   	else
       		echo
   	fi

--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -112,7 +112,7 @@ fn_backup_compression(){
 	sleep 2
 	fn_print_dots "Backup (${rootdirduexbackup}) ${backupname}.tar.gz, in progress..."
 	fn_script_log_info "backup ${rootdirduexbackup} ${backupname}.tar.gz, in progress"
-	excludedir=fn_backup_relpath
+        excludedir=$(fn_backup_relpath)
 	# CHECK THAT excludedir isn't empty.  Sanity check here -CedarLUG
 	tar -czf "${backupdir}/${backupname}.tar.gz" -C "${rootdir}" --exclude "${excludedir}" ./*
 	local exitcode=$?

--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -188,7 +188,7 @@ fn_backup_relpath() {
   	declare -a bdirtoks=($(readlink -f "${backupdir}" | sed "s/\// /g"))
 	# CHECK THAT the array is populated correctly.  Sanity check here -CedarLUG
 
-  	for ((base=0; $base<${#rdirtoks[@]}; base++)) ;
+  	for ((base=0; $base<${#rdirtoks[@]}; base++))
   	do
       		[[ "${rdirtoks[$base]}" != "${bdirtoks[$base]}" ]] && break
   	done


### PR DESCRIPTION
Adding a function to bypass the idiosyncrasies of different realpath implementations which use different syntax.

Also adds an exclusion for backing up the lockfile in the backup tarball.
Ref: #1727, #1752
