### PR TITLE
Update _default.cfg

### DIFF
--- a/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
@@ -9,8 +9,8 @@
 #### Server Settings ####
 
 ## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
-steamuser="username"
-steampass='password'
+steamuser="anonymous"
+steampass=''
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 ip="0.0.0.0"


### PR DESCRIPTION
Replacing the steam login details with an anonymous login will allow the install of the 7dtd server to complete successfully without having to edit common.cfg beforehand (which is only created when you run ./sdtdserver install which fails). The webpage information is misleading currently, telling you to edit a file that doesn't yet exist.