### PR TITLE
sdtd doesn't need steam login anymore

### DIFF
--- a/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
@@ -8,10 +8,6 @@
 
 #### Server Settings ####
 
-## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
-steamuser="username"
-steampass='password'
-
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 ip="0.0.0.0"
 


### PR DESCRIPTION
Fix is easy, removing steam vars makes LinuxGSM use anonymous login :)