### PR TITLE
Fix support bot config

### DIFF
--- a/.github/support.yml
+++ b/.github/support.yml
@@ -1,7 +1,7 @@
 # Configuration for support-requests - https://github.com/dessant/support-requests
 
 # Label used to mark issues as support requests
-supportLabel: Type: support
+supportLabel: "Type: support"
 # Comment to post on issues marked as support requests. Add a link
 # to a support page, or set to `false` to disable
 supportComment: >


### PR DESCRIPTION
Got a Sentry notification for the bot instance with this error:
```
incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line at line 4, column 19:
    supportLabel: Type: support
```