### PR TITLE
Fixes tmux handling of similar session names

### DIFF
--- a/lgsm/functions/check_status.sh
+++ b/lgsm/functions/check_status.sh
@@ -32,5 +32,5 @@ elif [ "${gamename}" == "Mumble" ]; then
 		status=1
 	fi
 else
-	status=$(tmux list-sessions -F "#{session_name}" | grep -Ecx "^${servicename}")
+	status=$(tmux list-sessions -F "#{session_name}" 2>/dev/null | grep -Ecx "^${servicename}")
 fi

--- a/lgsm/functions/check_status.sh
+++ b/lgsm/functions/check_status.sh
@@ -32,5 +32,5 @@ elif [ "${gamename}" == "Mumble" ]; then
 		status=1
 	fi
 else
-	status=$(tmux list-sessions 2>&1 | awk '{print $1}' | grep -Ec "^${servicename}:")
+	status=$(tmux list-sessions -F "#{session_name}" | grep -Ecx "^${servicename}")
 fi

--- a/lgsm/functions/command_start.sh
+++ b/lgsm/functions/command_start.sh
@@ -74,14 +74,16 @@ fn_start_tmux(){
 
 	# Log rotation
 	fn_script_log_info "Rotating log files"
-	if [ "${engine}" == "unreal2" ]; then
-		if [ -f "${gamelog}" ]; then
-			mv "${gamelog}" "${gamelogdate}"
-		fi
+	if [ "${engine}" == "unreal2" ]&&[ -f "${gamelog}" ]; then
+		mv "${gamelog}" "${gamelogdate}"
+	fi
+	if [ -f "${lgsmlog}" ]; then
 		mv "${lgsmlog}" "${lgsmlogdate}"
+	fi
+	if [ -f "${consolelog}" ]; then
 		mv "${consolelog}" "${consolelogdate}"
 	fi
-
+	
 	# Create lockfile
 	date > "${rootdir}/${lockselfname}"
 	cd "${executabledir}"

--- a/lgsm/functions/command_start.sh
+++ b/lgsm/functions/command_start.sh
@@ -83,7 +83,7 @@ fn_start_tmux(){
 	if [ -f "${consolelog}" ]; then
 		mv "${consolelog}" "${consolelogdate}"
 	fi
-	
+
 	# Create lockfile
 	date > "${rootdir}/${lockselfname}"
 	cd "${executabledir}"

--- a/lgsm/functions/command_start.sh
+++ b/lgsm/functions/command_start.sh
@@ -97,7 +97,7 @@ fn_start_tmux(){
 		fn_script_log "Tmux version: master (user compiled)"
 		echo "Tmux version: master (user compiled)" >> "${consolelog}"
 		if [ "${consolelogging}" == "on" ]||[ -z "${consolelogging}" ]; then
-			tmux pipe-pane -o -t="${servicename}" "exec cat >> '${consolelog}'"
+			tmux pipe-pane -o -t "${servicename}" "exec cat >> '${consolelog}'"
 		fi
 	elif [ -n "${tmuxversion}" ]; then
 		# Get the digit version of tmux
@@ -115,7 +115,7 @@ fn_start_tmux(){
 			Currently installed: $(tmux -V)" > "${consolelog}"
 		# Console logging enable or not set
 		elif [ "${consolelogging}" == "on" ]||[ -z "${consolelogging}" ]; then
-			tmux pipe-pane -o -t="${servicename}" "exec cat >> '${consolelog}'"
+			tmux pipe-pane -o -t "${servicename}" "exec cat >> '${consolelog}'"
 		fi
 	else
 		echo "Unable to detect tmux version" >> "${consolelog}"

--- a/lgsm/functions/command_start.sh
+++ b/lgsm/functions/command_start.sh
@@ -25,14 +25,6 @@ fn_start_teamspeak3(){
 		touch "${servercfgfullpath}"
 	fi
 	sleep 0.5
-	check_status.sh
-	if [ "${status}" != "0" ]; then
-		fn_print_info_nl "${servername} is already running"
-		fn_script_log_error "${servername} is already running"
-		if [ -z "${exitbypass}" ]; then
-			core_exit.sh
-		fi
-	fi
 	if [ -f "${lgsmlog}" ]; then
 		mv "${lgsmlog}" "${lgsmlogdate}"
 	fi
@@ -81,26 +73,13 @@ fn_start_tmux(){
 	fi
 
 	# Log rotation
-	check_status.sh
-	if [ "${status}" == "0" ]; then
-		fn_script_log_info "Rotating log files"
-		if [ "${engine}" == "unreal2" ]; then
-			if [ -f "${gamelog}" ]; then
-				mv "${gamelog}" "${gamelogdate}"
-			fi
+	fn_script_log_info "Rotating log files"
+	if [ "${engine}" == "unreal2" ]; then
+		if [ -f "${gamelog}" ]; then
+			mv "${gamelog}" "${gamelogdate}"
 		fi
 		mv "${lgsmlog}" "${lgsmlogdate}"
 		mv "${consolelog}" "${consolelogdate}"
-	fi
-
-	# If server is already running exit
-	check_status.sh
-	if [ "${status}" != "0" ]; then
-		fn_print_info_nl "${servername} is already running"
-		fn_script_log_error "${servername} is already running"
-		if [ -z "${exitbypass}" ]; then
-			core_exit.sh
-		fi
 	fi
 
 	# Create lockfile
@@ -209,17 +188,23 @@ sleep 0.5
 fn_print_dots "${servername}"
 sleep 0.5
 check.sh
+# Is the server already started
+if [ "${status}" != "0" ]; then # $status comes from check_status.sh, which is run by check.sh for this command
+	fn_print_info_nl "${servername} is already running"
+	fn_script_log_error "${servername} is already running"
+	if [ -z "${exitbypass}" ]; then
+		core_exit.sh
+	fi
+fi
 fix.sh
 info_config.sh
 logs.sh
 
 # Will check for updates is updateonstart is yes
-if [ "${status}" == "0" ]; then
-	if [ "${updateonstart}" == "yes" ]||[ "${updateonstart}" == "1" ]||[ "${updateonstart}" == "on" ]; then
-		exitbypass=1
-		unset updateonstart
-		command_update.sh
-	fi
+if [ "${updateonstart}" == "yes" ]||[ "${updateonstart}" == "1" ]||[ "${updateonstart}" == "on" ]; then
+	exitbypass=1
+	unset updateonstart
+	command_update.sh
 fi
 
 if [ "${gamename}" == "TeamSpeak 3" ]; then

--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -261,8 +261,6 @@ fn_stop_tmux(){
 	sleep 0.5
 	check_status.sh
 	if [ "${status}" == "0" ]; then
-		# Remove lockfile
-		rm -f "${rootdir}/${lockselfname}"
 		# ARK doesn't clean up immediately after tmux is killed.
 		# Make certain the ports are cleared before continuing.
 		if [ "${gamename}" == "ARK: Survival Evolved" ]; then
@@ -299,4 +297,8 @@ sleep 0.5
 check.sh
 info_config.sh
 fn_stop_pre_check
+# Remove lockfile
+if [ -f "${rootdir}/${lockselfname}" ]; then
+	rm -f "${rootdir}/${lockselfname}"
+fi
 core_exit.sh

--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -277,28 +277,21 @@ fn_stop_tmux(){
 		fn_print_ok_nl "${servername}"
 		fn_script_log_pass "Stopped ${servername}"
 	else
-		fn_print_fail_nl "Unable to stop${servername}"
-		fn_script_log_fatal "Unable to stop${servername}"
+		fn_print_fail_nl "Unable to stop ${servername}"
+		fn_script_log_fatal "Unable to stop ${servername}"
 	fi
 }
 
 # checks if the server is already stopped before trying to stop.
 fn_stop_pre_check(){
-	if [ "${gamename}" == "TeamSpeak 3" ]; then
-		check_status.sh
-		if [ "${status}" == "0" ]; then
-			fn_print_info_nl "${servername} is already stopped"
-			fn_script_log_error "${servername} is already stopped"
-		else
-			fn_stop_teamspeak3
-		fi
+# Is the server already stopped
+	if [ "${status}" == "0" ]; then # $status comes from check_status.sh, which is run by check.sh for this command
+		fn_print_info_nl "${servername} is already stopped"
+		fn_script_log_error "${servername} is already stopped"
+	elif [ "${gamename}" == "TeamSpeak 3" ]; then
+		fn_stop_teamspeak3
 	else
-		if [ "${status}" == "0" ]; then
-			fn_print_info_nl "${servername} is already stopped"
-			fn_script_log_error "${servername} is already stopped"
-		else
-			fn_stop_graceful_select
-		fi
+		fn_stop_graceful_select
 	fi
 }
 

--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -34,7 +34,6 @@ fn_stop_graceful_ctrlc(){
 		fn_script_log_error "Graceful: CTRL+c: FAIL"
 	fi
 	sleep 0.5
-	fn_stop_tmux
 }
 
 # Attempts graceful shutdown by sending a specified command.
@@ -64,7 +63,6 @@ fn_stop_graceful_cmd(){
 		fn_script_log_error "Graceful: sending \"${1}\": FAIL"
 	fi
 	sleep 0.5
-	fn_stop_tmux
 }
 
 # Attempts graceful of goldsource using rcon 'quit' command.
@@ -85,7 +83,6 @@ fn_stop_graceful_goldsource(){
 	fn_print_ok_eol_nl
 	fn_script_log_pass "Graceful: sending \"quit\": OK: ${seconds} seconds"
 	sleep 0.5
-	fn_stop_tmux
 }
 
 # Attempts graceful of 7 Days To Die using telnet.
@@ -174,7 +171,6 @@ fn_stop_graceful_sdtd(){
 		fn_script_log_warn "Graceful: telnet: expect not installed: FAIL"
 	fi
 	sleep 0.5
-	fn_stop_tmux
 }
 
 fn_stop_graceful_select(){
@@ -195,8 +191,6 @@ fn_stop_graceful_select(){
 		fn_stop_graceful_ctrlc
 	elif  [ "${engine}" == "source" ]||[ "${engine}" == "quake" ]||[ "${engine}" == "idtech2" ]||[ "${engine}" == "idtech3" ]||[ "${engine}" == "idtech3_ql" ]||[ "${engine}" == "Just Cause 2" ]||[ "${engine}" == "projectzomboid" ]||[ "${shortname}" == "rw" ]; then
 		fn_stop_graceful_cmd "quit" 30
-	else
-		fn_stop_tmux
 	fi
 }
 
@@ -292,6 +286,11 @@ fn_stop_pre_check(){
 		fn_stop_teamspeak3
 	else
 		fn_stop_graceful_select
+	fi
+	# Check status again, a stop tmux session if needed
+	check_status.sh
+	if [ "${status}" != "0" ]; then
+		fn_stop_tmux
 	fi
 }
 


### PR DESCRIPTION
This is probably my (not to say "THE") best PR in a while! It resolves an old issue (since LinuxGSM uses TMUX I think) where the wrong tmux session gets killed when they got similar names.

Example: 
```
./csgoserver start
[  OK  ] Starting csgoserver: LinuxGSM
./csgoserver-2 start
[  OK  ] Starting csgoserver-2: LinuxGSM
./csgoserver stop
[  OK  ] Stopping csgoserver: Graceful: sending "quit": 2: OK
./csgoserver-2 stop
[ INFO ] Stopping inferno-2: LinuxGSM is already stopped
```

The reason is:
When graceful shutdown works, probably because of pipe-pane or for whatever reason, the tmux session dies. But `fn_stop_tmux` was ran anyways because it made sense in termes of code. But that caused a command like `tmux kill-session -t csgoserver ` to be ran after the session died, so the command affected the closest matching alternate, like `csgoserver-2` tmux session. Because yes... tmux aproximates session names, which is cool for lazy people, but not cool when you seek precision. 

Anyway, it forced a little more cautiousness, which lead me to finding this, as well as some minor issues with the code.

The main change in this PR is that we make sure to run the session kill only when required. But some duplicate tests were removed as well, and some tests reorganized, which leads to a more simple and more comprehensible code.

It seems pretty right to me now, tested with csgo, and resolved the few issues pointed by our dear Travis.

Let's merge this to develop first for further testing until you think it is ready for master!