### PR TITLE
Use +maxplayers instead of -maxplayers

### DIFF
--- a/lgsm/config-default/config-lgsm/svenserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/svenserver/_default.cfg
@@ -17,7 +17,7 @@ maxplayers="16"
 
 ## Server Start Command | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters#additional-parameters
 fn_parms(){
-parms="-game svencoop -strictportbind +ip ${ip} -port ${port} +clientport ${clientport} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
+parms="-game svencoop -strictportbind +ip ${ip} -port ${port} +clientport ${clientport} +map ${defaultmap} +servercfgfile ${servercfg} +maxplayers ${maxplayers}"
 }
 
 #### LinuxGSM Settings ####


### PR DESCRIPTION
Svencoop uses +maxplayers to specify max players, not -maxplayers. If -maxplayers is utilized, it will default to 2 slots regardless of specified players.