### PR TITLE
Updated rust Wipe feature & fixed updating when githubbranch differs

### DIFF
--- a/lgsm/functions/command_update_linuxgsm.sh
+++ b/lgsm/functions/command_update_linuxgsm.sh
@@ -43,7 +43,7 @@ if [ -z "${legacymode}" ]; then
 		fn_print_ok_eol_nl
 	fi
 	echo -ne "    checking ${selfname}...\c"
-	script_diff=$(diff <(sed '/shortname/d;/gameservername/d;/gamename/d' "${tmpdir}/linuxgsm.sh") <(sed '/shortname/d;/gameservername/d;/gamename/d' "${rootdir}/${selfname}"))
+	script_diff=$(diff <(sed '/shortname/d;/gameservername/d;/gamename/d;githubuser/d;githubrepo/d;githubbranch/d' "${tmpdir}/linuxgsm.sh") <(sed '/shortname/d;/gameservername/d;/gamename/d;githubuser/d;githubrepo/d;githubbranch/d' "${rootdir}/${selfname}"))
 	if [ "${script_diff}" != "" ]; then
 		fn_print_update_eol_nl
 		echo -ne "    backup ${selfname}...\c"

--- a/lgsm/functions/command_update_linuxgsm.sh
+++ b/lgsm/functions/command_update_linuxgsm.sh
@@ -43,7 +43,7 @@ if [ -z "${legacymode}" ]; then
 		fn_print_ok_eol_nl
 	fi
 	echo -ne "    checking ${selfname}...\c"
-	script_diff=$(diff <(sed '/shortname/d;/gameservername/d;/gamename/d;githubuser/d;githubrepo/d;githubbranch/d' "${tmpdir}/linuxgsm.sh") <(sed '/shortname/d;/gameservername/d;/gamename/d;githubuser/d;githubrepo/d;githubbranch/d' "${rootdir}/${selfname}"))
+	script_diff=$(diff <(sed '@shortname@d;@gameservername@d;@gamename@d;githubuser@d;githubrepo@d;githubbranch@d' "${tmpdir}/linuxgsm.sh") <(sed '@shortname@d;@gameservername@d;@gamename@d;githubuser@d;githubrepo@d;githubbranch@d' "${rootdir}/${selfname}"))
 	if [ "${script_diff}" != "" ]; then
 		fn_print_update_eol_nl
 		echo -ne "    backup ${selfname}...\c"

--- a/lgsm/functions/command_update_linuxgsm.sh
+++ b/lgsm/functions/command_update_linuxgsm.sh
@@ -43,7 +43,7 @@ if [ -z "${legacymode}" ]; then
 		fn_print_ok_eol_nl
 	fi
 	echo -ne "    checking ${selfname}...\c"
-	script_diff=$(diff <(sed '\/shortname/d;\/gameservername/d;/\gamename/d;\/githubuser/d;\/githubrepo/d;\/githubbranch/d' "${tmpdir}/linuxgsm.sh") <(sed '\/shortname/d;\/gameservername/d;\/gamename/d;\/githubuser/d;\/githubrepo/d;\/githubbranch/d' "${rootdir}/${selfname}"))
+	script_diff=$(diff <(sed '\/shortname/d;\/gameservername/d;\/gamename/d;\/githubuser/d;\/githubrepo/d;\/githubbranch/d' "${tmpdir}/linuxgsm.sh") <(sed '\/shortname/d;\/gameservername/d;\/gamename/d;\/githubuser/d;\/githubrepo/d;\/githubbranch/d' "${rootdir}/${selfname}"))
 	if [ "${script_diff}" != "" ]; then
 		fn_print_update_eol_nl
 		echo -ne "    backup ${selfname}...\c"

--- a/lgsm/functions/command_update_linuxgsm.sh
+++ b/lgsm/functions/command_update_linuxgsm.sh
@@ -43,7 +43,7 @@ if [ -z "${legacymode}" ]; then
 		fn_print_ok_eol_nl
 	fi
 	echo -ne "    checking ${selfname}...\c"
-	script_diff=$(diff <(sed '/shortname/d;/gameservername/d;/gamename/d;githubuser/d;/githubrepo/d;/githubbranch/d' "${tmpdir}/linuxgsm.sh") <(sed '/shortname/d;/gameservername/d;/gamename/d;/githubuser/d;/githubrepo/d;/githubbranch/d' "${rootdir}/${selfname}"))
+	script_diff=$(diff <(sed '/shortname/d;/gameservername/d;/gamename/d;/githubuser/d;/githubrepo/d;/githubbranch/d' "${tmpdir}/linuxgsm.sh") <(sed '/shortname/d;/gameservername/d;/gamename/d;/githubuser/d;/githubrepo/d;/githubbranch/d' "${rootdir}/${selfname}"))
 	if [ "${script_diff}" != "" ]; then
 		fn_print_update_eol_nl
 		echo -ne "    backup ${selfname}...\c"

--- a/lgsm/functions/command_update_linuxgsm.sh
+++ b/lgsm/functions/command_update_linuxgsm.sh
@@ -43,7 +43,7 @@ if [ -z "${legacymode}" ]; then
 		fn_print_ok_eol_nl
 	fi
 	echo -ne "    checking ${selfname}...\c"
-	script_diff=$(diff <(sed '@shortname@d;@gameservername@d;@gamename@d;githubuser@d;githubrepo@d;githubbranch@d' "${tmpdir}/linuxgsm.sh") <(sed '@shortname@d;@gameservername@d;@gamename@d;githubuser@d;githubrepo@d;githubbranch@d' "${rootdir}/${selfname}"))
+	script_diff=$(diff <(sed '/shortname/d;/gameservername/d;/gamename/d;githubuser/d;/githubrepo/d;/githubbranch/d' "${tmpdir}/linuxgsm.sh") <(sed '/shortname/d;/gameservername/d;/gamename/d;/githubuser/d;/githubrepo/d;/githubbranch/d' "${rootdir}/${selfname}"))
 	if [ "${script_diff}" != "" ]; then
 		fn_print_update_eol_nl
 		echo -ne "    backup ${selfname}...\c"

--- a/lgsm/functions/command_update_linuxgsm.sh
+++ b/lgsm/functions/command_update_linuxgsm.sh
@@ -43,7 +43,7 @@ if [ -z "${legacymode}" ]; then
 		fn_print_ok_eol_nl
 	fi
 	echo -ne "    checking ${selfname}...\c"
-	script_diff=$(diff <(sed '/shortname/d;/gameservername/d;/gamename/d;/githubuser/d;/githubrepo/d;/githubbranch/d' "${tmpdir}/linuxgsm.sh") <(sed '/shortname/d;/gameservername/d;/gamename/d;/githubuser/d;/githubrepo/d;/githubbranch/d' "${rootdir}/${selfname}"))
+	script_diff=$(diff <(sed '\/shortname/d;\/gameservername/d;/\gamename/d;\/githubuser/d;\/githubrepo/d;\/githubbranch/d' "${tmpdir}/linuxgsm.sh") <(sed '\/shortname/d;\/gameservername/d;\/gamename/d;\/githubuser/d;\/githubrepo/d;\/githubbranch/d' "${rootdir}/${selfname}"))
 	if [ "${script_diff}" != "" ]; then
 		fn_print_update_eol_nl
 		echo -ne "    backup ${selfname}...\c"

--- a/lgsm/functions/command_wipe.sh
+++ b/lgsm/functions/command_wipe.sh
@@ -58,7 +58,7 @@ fn_wipe_server_remove_files(){
 			fn_script_log_info "No procedural map file to remove."
 			sleep 0.5
 		fi
-		#Wipe procedural map save
+		# Wipe procedural map save
 		if [ -n "$(find "${serveridentitydir}" -type f -name "proceduralmap.*.sav")" ]; then
 			currentaction="Removing procedural map save(s): ${serveridentitydir}/proceduralmap.*.sav"
 			echo -en "Removing map saves proceduralmap.*.sav file(s)..."

--- a/lgsm/functions/command_wipe.sh
+++ b/lgsm/functions/command_wipe.sh
@@ -140,7 +140,7 @@ fn_wipe_server_remove_files(){
 		if [ "${wipeall}" == "1" ]; then
 			if [ -n "$(find "${serveridentitydir}" -type f -name "player.blueprints.*.db")" ]; then
 				currentaction="Removing blueprint file(s): ${serveridentitydir}/player.blueprints.*.db"
-				echo -en "Removing procedural blueprints player.blueprints.*.db file(s)..."
+				echo -en "Removing blueprints player.blueprints.*.db file(s)..."
 				sleep 0.5
 				fn_script_log "${currentaction}"
 				find "${serveridentitydir:?}" -type f -name "player.blueprints.*.db" -delete

--- a/lgsm/functions/command_wipe.sh
+++ b/lgsm/functions/command_wipe.sh
@@ -151,7 +151,7 @@ fn_wipe_server_remove_files(){
 				fn_script_log_info "No blueprint file to remove."
 				sleep 0.5
 			fi
-		elif [ -n "$(find "${serveridentitydir}" -type f -name "player.blueprints.*.db")" ]
+		elif [ -n "$(find "${serveridentitydir}" -type f -name "player.blueprints.*.db")" ]; then
 				fn_print_information_nl "Keeping blueprints"
 				fn_script_log_info "Keeping blueprints."
 				sleep 0.5

--- a/lgsm/functions/command_wipe.sh
+++ b/lgsm/functions/command_wipe.sh
@@ -122,6 +122,17 @@ fn_wipe_server_remove_files(){
 			sleep 0.5
 		# We do not print additional information if there is nothing to remove since this might be obsolete
 		fi
+		# Wipe sv.files
+		if [ -n "$(find "${serveridentitydir}" -type f -name "sv.files.*.db")" ]; then
+			currentaction="Removing server misc files: ${serveridentitydir}/sv.files.*.db"
+			echo -en "Removing server misc srv.files*.db file(s)..."
+			sleep 0.5
+			fn_script_log "${currentaction}"
+			find "${serveridentitydir:?}" -type f -name "sv.files.*.d" -delete
+			fn_wipe_exit_code
+			sleep 0.5
+		# No further information if not found because it should I could not get this file showing up
+		fi
 		# Wipe player death files
 		if [ -n "$(find "${serveridentitydir}" -type f -name "player.deaths.*.db")" ]; then
 			currentaction="Removing player death files: ${serveridentitydir}/player.deaths.*.db"
@@ -178,7 +189,7 @@ fn_wipe_server_remove_files(){
 # Check if there is something to wipe, prompt the user, and call appropriate functions
 # Rust Wipe
 if [ "${gamename}" == "Rust" ]; then
-	if [ -d "${serveridentitydir}/storage" ]||[ -d "${serveridentitydir}/user" ]||[ -n "$(find "${serveridentitydir}" -type f -name "proceduralmap*.sav")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "barren*.sav")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "Log.*.txt")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "player.deaths.*.db")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "player.blueprints.*.db")" ]; then
+	if [ -d "${serveridentitydir}/storage" ]||[ -d "${serveridentitydir}/user" ]||[ -n "$(find "${serveridentitydir}" -type f -name "proceduralmap*.sav")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "barren*.sav")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "Log.*.txt")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "player.deaths.*.db")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "player.blueprints.*.db")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "sv.files.*.db")" ]; then
 		fn_print_warning_nl "Any user, storage, log and map data from ${serveridentitydir} will be erased."
 		if ! fn_prompt_yn "Continue?" Y; then
 				echo Exiting; core_exit.sh

--- a/lgsm/functions/command_wipe.sh
+++ b/lgsm/functions/command_wipe.sh
@@ -43,36 +43,8 @@ fn_wipe_exit_code(){
 # Removes files to wipe server
 fn_wipe_server_remove_files(){
 	# Rust Wipe
-#WipeProceduralSave
 	if [ "${gamename}" == "Rust" ]; then
-		if [ -n "$(find "${serveridentitydir}" -type f -name "proceduralmap.*.sav")" ]; then
-			currentaction="Removing procedural map save(s): ${serveridentitydir}/proceduralmap.*.sav"
-			echo -en "Removing map saves proceduralmap.*.sav file(s)..."
-			sleep 0.5
-			fn_script_log "${currentaction}"
-			find "${serveridentitydir:?}" -type f -name "proceduralmap.*.sav" -delete
-			fn_wipe_exit_code
-			sleep 0.5
-		else
-			fn_print_information_nl "No procedural map save to remove"
-			fn_script_log_info "No procedural map save to remove."
-			sleep 0.5
-		fi
-#WipeBarrenSave
-			if [ -n "$(find "${serveridentitydir}" -type f -name "barren*.sav")" ]; then
-			currentaction="Removing barren map save(s): ${serveridentitydir}/barren*.sav"
-			echo -en "Removing barren map saves barren*.sav file(s)..."
-			sleep 0.5
-			fn_script_log "${currentaction}"
-			find "${serveridentitydir:?}" -type f -name "barren*.sav" -delete
-			fn_wipe_exit_code
-			sleep 0.5
-		else
-			fn_print_information_nl "No barren map save to remove"
-			fn_script_log_info "No barren map save to remove."
-			sleep 0.5
-		fi
-#WipeProceduralMap
+		# Wipe pocedural map
 		if [ -n "$(find "${serveridentitydir}" -type f -name "proceduralmap.*.map")" ]; then
 			currentaction="Removing map file(s): ${serveridentitydir}/proceduralmap.*.map"
 			echo -en "Removing procedural map proceduralmap.*.map file(s)..."
@@ -86,8 +58,22 @@ fn_wipe_server_remove_files(){
 			fn_script_log_info "No procedural map file to remove."
 			sleep 0.5
 		fi
-#WipeBarrenMap
-				if [ -n "$(find "${serveridentitydir}" -type f -name "barren*.map")" ]; then
+		#Wipe procedural map save
+		if [ -n "$(find "${serveridentitydir}" -type f -name "proceduralmap.*.sav")" ]; then
+			currentaction="Removing procedural map save(s): ${serveridentitydir}/proceduralmap.*.sav"
+			echo -en "Removing map saves proceduralmap.*.sav file(s)..."
+			sleep 0.5
+			fn_script_log "${currentaction}"
+			find "${serveridentitydir:?}" -type f -name "proceduralmap.*.sav" -delete
+			fn_wipe_exit_code
+			sleep 0.5
+		else
+			fn_print_information_nl "No procedural map save to remove"
+			fn_script_log_info "No procedural map save to remove."
+			sleep 0.5
+		fi
+		# Wipe Barren map
+		if [ -n "$(find "${serveridentitydir}" -type f -name "barren*.map")" ]; then
 			currentaction="Removing map file(s): ${serveridentitydir}/barren*.map"
 			echo -en "Removing barren map barren*.map file(s)..."
 			sleep 0.5
@@ -100,6 +86,21 @@ fn_wipe_server_remove_files(){
 			fn_script_log_info "No barren map file to remove."
 			sleep 0.5
 		fi
+		# Wipe barren map save
+		if [ -n "$(find "${serveridentitydir}" -type f -name "barren*.sav")" ]; then
+			currentaction="Removing barren map save(s): ${serveridentitydir}/barren*.sav"
+			echo -en "Removing barren map saves barren*.sav file(s)..."
+			sleep 0.5
+			fn_script_log "${currentaction}"
+			find "${serveridentitydir:?}" -type f -name "barren*.sav" -delete
+			fn_wipe_exit_code
+			sleep 0.5
+		else
+			fn_print_information_nl "No barren map save to remove"
+			fn_script_log_info "No barren map save to remove."
+			sleep 0.5
+		fi
+		# Wipe user dir, might be a legacy thing, maybe to be removed
 		if [ -d "${serveridentitydir}/user" ]; then
 			currentaction="Removing user directory: ${serveridentitydir}/user"
 			echo -en "Removing user directory..."
@@ -108,11 +109,9 @@ fn_wipe_server_remove_files(){
 			rm -rf "${serveridentitydir:?}/user"
 			fn_wipe_exit_code
 			sleep 0.5
-		else
-			fn_print_information_nl "No user directory to remove"
-			fn_script_log_info "No user directory to remove."
-			sleep 0.5
+		# We do not print additional information if there is nothing to remove since this might be obsolete
 		fi
+		# Wipe storage dir, might be a legacy thing, maybe to be removed
 		if [ -d "${serveridentitydir}/storage" ]; then
 			currentaction="Removing storage directory: ${serveridentitydir}/storage"
 			echo -en "Removing storage directory..."
@@ -121,11 +120,47 @@ fn_wipe_server_remove_files(){
 			rm -rf "${serveridentitydir:?}/storage"
 			fn_wipe_exit_code
 			sleep 0.5
+		# We do not print additional information if there is nothing to remove since this might be obsolete
+		fi
+		# Wipe player death files
+		if [ -n "$(find "${serveridentitydir}" -type f -name "player.deaths.*.db")" ]; then
+			currentaction="Removing player death files: ${serveridentitydir}/player.deaths.*.db"
+			echo -en "Removing player deaths player.deaths.*.db file(s)..."
+			sleep 0.5
+			fn_script_log "${currentaction}"
+			find "${serveridentitydir:?}" -type f -name "player.deaths.*.db" -delete
+			fn_wipe_exit_code
+			sleep 0.5
 		else
-			fn_print_information_nl "No storage directory to remove"
-			fn_script_log_info "No storage directory to remove."
+			fn_print_information_nl "No player death to remove"
+			fn_script_log_info "No player death to remove."
 			sleep 0.5
 		fi
+		# Wipe blueprints only if wipeall command was used
+		if [ "${wipeall}" == "1" ]; then
+			if [ -n "$(find "${serveridentitydir}" -type f -name "player.blueprints.*.db")" ]; then
+				currentaction="Removing blueprint file(s): ${serveridentitydir}/player.blueprints.*.db"
+				echo -en "Removing procedural blueprints player.blueprints.*.db file(s)..."
+				sleep 0.5
+				fn_script_log "${currentaction}"
+				find "${serveridentitydir:?}" -type f -name "player.blueprints.*.db" -delete
+				fn_wipe_exit_code
+				sleep 0.5
+			else
+				fn_print_information_nl "No blueprint file to remove"
+				fn_script_log_info "No blueprint file to remove."
+				sleep 0.5
+			fi
+		elif [ -n "$(find "${serveridentitydir}" -type f -name "player.blueprints.*.db")" ]
+				fn_print_information_nl "Keeping blueprints"
+				fn_script_log_info "Keeping blueprints."
+				sleep 0.5
+		else
+				fn_print_information_nl "No blueprints found"
+				fn_script_log_info "No blueprints found."
+				sleep 0.5				
+		fi
+		# Wipe some logs that might be there
 		if [ -n "$(find "${serveridentitydir}" -type f -name "Log.*.txt")" ]; then
 			currentaction="Removing log files: ${serveridentitydir}/Log.*.txt"
 			echo -en "Removing Log files..."
@@ -134,10 +169,7 @@ fn_wipe_server_remove_files(){
 			find "${serveridentitydir:?}" -type f -name "Log.*.txt" -delete
 			fn_wipe_exit_code
 			sleep 0.5
-		else
-			fn_print_information_nl "No log files to remove"
-			fn_script_log_info "No log files to remove."
-			sleep 0.5
+		# We do not print additional information if there are no logs to remove
 		fi
 	# You can add an "elif" here to add another game or engine
 	fi
@@ -146,7 +178,7 @@ fn_wipe_server_remove_files(){
 # Check if there is something to wipe, prompt the user, and call appropriate functions
 # Rust Wipe
 if [ "${gamename}" == "Rust" ]; then
-	if [ -d "${serveridentitydir}/storage" ]||[ -d "${serveridentitydir}/user" ]||[ -n "$(find "${serveridentitydir}" -type f -name "proceduralmap*.sav")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "barren*.sav")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "Log.*.txt")" ]; then
+	if [ -d "${serveridentitydir}/storage" ]||[ -d "${serveridentitydir}/user" ]||[ -n "$(find "${serveridentitydir}" -type f -name "proceduralmap*.sav")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "barren*.sav")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "Log.*.txt")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "player.deaths.*.db")" ]||[ -n "$(find "${serveridentitydir}" -type f -name "player.blueprints.*.db")" ]; then
 		fn_print_warning_nl "Any user, storage, log and map data from ${serveridentitydir} will be erased."
 		if ! fn_prompt_yn "Continue?" Y; then
 				echo Exiting; core_exit.sh

--- a/lgsm/functions/core_getopt.sh
+++ b/lgsm/functions/core_getopt.sh
@@ -35,7 +35,8 @@ cmd_mods_update=( "mu;mods-update" "command_mods_update.sh" "Update installed mo
 # Server specific
 cmd_change_password=( "pw;change-password" "command_ts3_server_pass.sh" "Change TS3 serveradmin password." )
 cmd_install_default_resources=( "ir;install-default-resources" "command_install_resources_mta.sh" "Install the MTA default resources." )
-cmd_wipe=( "wi;wipe" "command_wipe.sh" "Wipe your server data." )
+cmd_wipe=( "wi;wipe" "command_wipe.sh" "Wipe your main game server data." )
+cmd_wipeall=( "fw;wipeall" "command_wipe.sh" "Wipe your game server data and blueprints." )
 cmd_map_compressor_u99=( "mc;map-compressor" "compress_ut99_maps.sh" "Compresses all ${gamename} server maps." )
 cmd_map_compressor_u2=( "mc;map-compressor" "compress_unreal2_maps.sh" "Compresses all ${gamename} server maps." )
 cmd_install_cdkey=( "cd;server-cd-key" "install_ut2k4_key.sh" "Add your server cd key." )
@@ -93,7 +94,7 @@ fi
 
 # Unreal exclusive
 if [ "${gamename}" == "Rust" ]; then
-	currentopt+=( "${cmd_wipe[@]}" )
+	currentopt+=( "${cmd_wipe[@]}" "${cmd_wipeall[@]}" )
 fi
 if [ "${engine}" == "unreal2" ]; then
 	if [ "${gamename}" == "Unreal Tournament 2004" ]; then

--- a/lgsm/functions/core_getopt.sh
+++ b/lgsm/functions/core_getopt.sh
@@ -36,7 +36,7 @@ cmd_mods_update=( "mu;mods-update" "command_mods_update.sh" "Update installed mo
 cmd_change_password=( "pw;change-password" "command_ts3_server_pass.sh" "Change TS3 serveradmin password." )
 cmd_install_default_resources=( "ir;install-default-resources" "command_install_resources_mta.sh" "Install the MTA default resources." )
 cmd_wipe=( "wi;wipe" "command_wipe.sh" "Wipe your main game server data." )
-cmd_wipeall=( "fw;wipeall" "fullwipe=1; command_wipe.sh" "Wipe your game server data and blueprints." )
+cmd_wipeall=( "wa;wipeall" "wipeall=1; command_wipe.sh" "Wipe your game server data and blueprints." )
 cmd_map_compressor_u99=( "mc;map-compressor" "compress_ut99_maps.sh" "Compresses all ${gamename} server maps." )
 cmd_map_compressor_u2=( "mc;map-compressor" "compress_unreal2_maps.sh" "Compresses all ${gamename} server maps." )
 cmd_install_cdkey=( "cd;server-cd-key" "install_ut2k4_key.sh" "Add your server cd key." )

--- a/lgsm/functions/core_getopt.sh
+++ b/lgsm/functions/core_getopt.sh
@@ -36,7 +36,7 @@ cmd_mods_update=( "mu;mods-update" "command_mods_update.sh" "Update installed mo
 cmd_change_password=( "pw;change-password" "command_ts3_server_pass.sh" "Change TS3 serveradmin password." )
 cmd_install_default_resources=( "ir;install-default-resources" "command_install_resources_mta.sh" "Install the MTA default resources." )
 cmd_wipe=( "wi;wipe" "command_wipe.sh" "Wipe your main game server data." )
-cmd_wipeall=( "fw;wipeall" "command_wipe.sh" "Wipe your game server data and blueprints." )
+cmd_wipeall=( "fw;wipeall" "fullwipe=1; command_wipe.sh" "Wipe your game server data and blueprints." )
 cmd_map_compressor_u99=( "mc;map-compressor" "compress_ut99_maps.sh" "Compresses all ${gamename} server maps." )
 cmd_map_compressor_u2=( "mc;map-compressor" "compress_unreal2_maps.sh" "Compresses all ${gamename} server maps." )
 cmd_install_cdkey=( "cd;server-cd-key" "install_ut2k4_key.sh" "Add your server cd key." )


### PR DESCRIPTION
fixes #1830 

- Reorganized the script
- Corrected comments
- Now wipes player.deaths.*.db
- Now wipes sv.files.*.db
- Does not output anything if legacy stuff is not found
- Added `wipeall` (or `wa`) command to wipe blueprints

Tested, works like charm.

For example:

````
ultimatebyte@gaben:~$ ./rustserver wa

Rust data wipe
=================================

Warning! Any user, storage, log and map data from /home/ultimatebyte/serverfiles/server/rustserver will be erased.
Continue? [Y/n] Y
Information! No procedural map file to remove
Information! No procedural map save to remove
Information! No barren map file to remove
Information! No barren map save to remove
Removing server misc srv.files*.db file(s)...OK
Information! No player death to remove
Removing blueprints player.blueprints.*.db file(s)...OK
server data wiped
````

Also fixes #1949
Now you can change branch in your script and not get it overwritten upon running update-functions. Way more convenient for development, at least with my workflow.