### PR TITLE
Use /proc/meminfo instead of free -m

### DIFF
--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -94,7 +94,7 @@ load=$(uptime|awk -F 'load average: ' '{ print $2 }')
 # Available RAM and swap.
 physmemtotalmb=$(($(grep MemTotal /proc/meminfo | awk '{print $2}')/1024))
 physmemtotal=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemTotal /proc/meminfo | awk '{print $2}')K")
-physmemfree=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemFree /proc/meminfo | awk '{print $2}')K")
+physmemfree=$(numfmt --to=iec --from=iec --suffix=B "$(($(grep ^MemFree /proc/meminfo | awk '{print $2}')-$(grep "^MemFree\:" /proc/meminfo | awk '{print $2}')+$(grep "^Buffers\:" /proc/meminfo | awk '{print $2}')+$(grep "^Cached\:" /proc/meminfo | awk '{print $2}')+$(grep "^SReclaimable\:" /proc/meminfo | awk '{print $2}')))K")
 physmemused=$(numfmt --to=iec --from=iec --suffix=B "$(($(grep "^MemTotal\:" /proc/meminfo | awk '{print $2}')-$(grep "^MemFree\:" /proc/meminfo | awk '{print $2}')-$(grep "^Buffers\:" /proc/meminfo | awk '{print $2}')-$(grep "^Cached\:" /proc/meminfo | awk '{print $2}')-$(grep "^SReclaimable\:" /proc/meminfo | awk '{print $2}')))K")
 { # try
 	physmemavailable=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemAvailable /proc/meminfo | awk '{print $2}')K")

--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -94,7 +94,7 @@ load=$(uptime|awk -F 'load average: ' '{ print $2 }')
 # Available RAM and swap.
 physmemtotalmb=$(($(grep MemTotal /proc/meminfo | awk '{print $2}')/1024))
 physmemtotal=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemTotal /proc/meminfo | awk '{print $2}')K")
-physmemfree=$(numfmt --to=iec --from=iec --suffix=B "$(($(grep ^MemFree /proc/meminfo | awk '{print $2}')-$(grep "^MemFree\:" /proc/meminfo | awk '{print $2}')+$(grep "^Buffers\:" /proc/meminfo | awk '{print $2}')+$(grep "^Cached\:" /proc/meminfo | awk '{print $2}')+$(grep "^SReclaimable\:" /proc/meminfo | awk '{print $2}')))K")
+physmemfree=$(numfmt --to=iec --from=iec --suffix=B "$(($(grep ^MemFree /proc/meminfo | awk '{print $2}')+$(grep "^Buffers\:" /proc/meminfo | awk '{print $2}')+$(grep "^Cached\:" /proc/meminfo | awk '{print $2}')+$(grep "^SReclaimable\:" /proc/meminfo | awk '{print $2}')))K")
 physmemused=$(numfmt --to=iec --from=iec --suffix=B "$(($(grep "^MemTotal\:" /proc/meminfo | awk '{print $2}')-$(grep "^MemFree\:" /proc/meminfo | awk '{print $2}')-$(grep "^Buffers\:" /proc/meminfo | awk '{print $2}')-$(grep "^Cached\:" /proc/meminfo | awk '{print $2}')-$(grep "^SReclaimable\:" /proc/meminfo | awk '{print $2}')))K")
 { # try
 	physmemavailable=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemAvailable /proc/meminfo | awk '{print $2}')K")

--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -94,7 +94,7 @@ load=$(uptime|awk -F 'load average: ' '{ print $2 }')
 # Available RAM and swap.
 physmemtotalmb=$(($(grep MemTotal /proc/meminfo | awk '{print $2}')/1024))
 physmemtotal=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemTotal /proc/meminfo | awk '{print $2}')K")
-physmemfree=$(numfmt --to=iec --from=iec --suffix=B "$(($(grep ^MemFree /proc/meminfo | awk '{print $2}')+$(grep "^Buffers\:" /proc/meminfo | awk '{print $2}')+$(grep "^Cached\:" /proc/meminfo | awk '{print $2}')+$(grep "^SReclaimable\:" /proc/meminfo | awk '{print $2}')))K")
+physmemfree=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemAvailable /proc/meminfo | awk '{print $2}')K")
 physmemused=$(numfmt --to=iec --from=iec --suffix=B "$(($(grep "^MemTotal\:" /proc/meminfo | awk '{print $2}')-$(grep "^MemFree\:" /proc/meminfo | awk '{print $2}')-$(grep "^Buffers\:" /proc/meminfo | awk '{print $2}')-$(grep "^Cached\:" /proc/meminfo | awk '{print $2}')-$(grep "^SReclaimable\:" /proc/meminfo | awk '{print $2}')))K")
 { # try
 	physmemavailable=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemAvailable /proc/meminfo | awk '{print $2}')K")

--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -90,31 +90,23 @@ days=$(( uptime/60/60/24 ))
 load=$(uptime|awk -F 'load average: ' '{ print $2 }')
 
 ## Memory information
+
 # Available RAM and swap.
-
-# Older versions of free do not support -h option.
-if [ "$(free -h > /dev/null 2>&1; echo $?)" -ne "0" ]; then
-	humanreadable="-m"
-else
-	humanreadable="-h"
-fi
-
-physmemtotal=$(free ${humanreadable} | awk '/Mem:/ {print $2}')
-physmemtotalmb=$(free -m | awk '/Mem:/ {print $2}')
-physmemused=$(free ${humanreadable} | awk '/Mem:/ {print $3}')
-physmemfree=$(free ${humanreadable} | awk '/Mem:/ {print $4}')
-oldfree=$(free ${humanreadable} | awk '/cache:/')
-if [ -n "${oldfree}" ]; then
+physmemtotalmb=$(($(grep MemTotal /proc/meminfo | awk '{print $2}')/1024))
+physmemtotal=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemTotal /proc/meminfo | awk '{print $2}')K")
+physmemfree=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemFree /proc/meminfo | awk '{print $2}')K")
+physmemused=$(numfmt --to=iec --from=iec --suffix=B "$(($(grep ^MemTotal /proc/meminfo | awk '{print $2}')-$(grep ^MemFree /proc/meminfo | awk '{print $2}')))K")
+{ # try
+	physmemavailable=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemAvailable /proc/meminfo | awk '{print $2}')K")
+	physmemcached=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^Cached /proc/meminfo | awk '{print $2}')K")
+} 2>/dev/null || { # fail silently, catch
 	physmemavailable="n/a"
 	physmemcached="n/a"
-else
-	physmemavailable=$(free ${humanreadable} | awk '/Mem:/ {print $7}')
-	physmemcached=$(free ${humanreadable} | awk '/Mem:/ {print $6}')
-fi
+}
 
-swaptotal=$(free ${humanreadable} | awk '/Swap:/ {print $2}')
-swapused=$(free ${humanreadable} | awk '/Swap:/ {print $3}')
-swapfree=$(free ${humanreadable} | awk '/Swap:/ {print $4}')
+swaptotal=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^SwapTotal /proc/meminfo | awk '{print $2}')K")
+swapfree=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^SwapFree /proc/meminfo | awk '{print $2}')K")
+swapused=$(numfmt --to=iec --from=iec --suffix=B "$(($(grep ^SwapTotal /proc/meminfo | awk '{print $2}')-$(grep ^SwapFree /proc/meminfo | awk '{print $2}')))K")
 
 ### Disk information
 

--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -95,10 +95,10 @@ load=$(uptime|awk -F 'load average: ' '{ print $2 }')
 physmemtotalmb=$(($(grep MemTotal /proc/meminfo | awk '{print $2}')/1024))
 physmemtotal=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemTotal /proc/meminfo | awk '{print $2}')K")
 physmemfree=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemFree /proc/meminfo | awk '{print $2}')K")
-physmemused=$(numfmt --to=iec --from=iec --suffix=B "$(($(grep ^MemTotal /proc/meminfo | awk '{print $2}')-$(grep ^MemFree /proc/meminfo | awk '{print $2}')))K")
+physmemused=$(numfmt --to=iec --from=iec --suffix=B "$(($(grep "^MemTotal\:" /proc/meminfo | awk '{print $2}')-$(grep "^MemFree\:" /proc/meminfo | awk '{print $2}')-$(grep "^Buffers\:" /proc/meminfo | awk '{print $2}')-$(grep "^Cached\:" /proc/meminfo | awk '{print $2}')-$(grep "^SReclaimable\:" /proc/meminfo | awk '{print $2}')))K")
 { # try
 	physmemavailable=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^MemAvailable /proc/meminfo | awk '{print $2}')K")
-	physmemcached=$(numfmt --to=iec --from=iec --suffix=B "$(grep ^Cached /proc/meminfo | awk '{print $2}')K")
+	physmemcached=$(numfmt --to=iec --from=iec --suffix=B "$(($(grep ^Cached /proc/meminfo | awk '{print $2}')+$(grep "^SReclaimable\:" /proc/meminfo | awk '{print $2}')))K")
 } 2>/dev/null || { # fail silently, catch
 	physmemavailable="n/a"
 	physmemcached="n/a"


### PR DESCRIPTION
Fixes #1970.

Also uses numfmt which is included in coreutils since version 8.24. _Edit: 8.21_
Ubuntu has this coreutils version since 16.04 _Edit: 14.04_ (https://packages.ubuntu.com/search?keywords=coreutils)
Debian has this coreutils version since 9 (stretch) _Edit: 8 (jessie)_ (https://packages.debian.org/search?keywords=coreutils)
Unfortunately I could neither find out which version of Fedora is necessary nor which other tool one can use to generate human-readable output from the number that we read from /proc/meminfo (which is in kB).