### PR TITLE
Fix OxideRust download link

### DIFF
--- a/lgsm/functions/mods_list.sh
+++ b/lgsm/functions/mods_list.sh
@@ -27,7 +27,7 @@ sourcemodlatestfile="$(wget "${sourcemodscrapeurl}" -q -O -)"
 sourcemoddownloadurl="https://www.sourcemod.net/latest.php?os=linux&version=${sourcemodmversion}"
 sourcemodurl="${sourcemoddownloadurl}"
 # Oxide
-oxiderustlatestlink="$(curl -s https://api.github.com/repos/OxideMod/Oxide.Rust/releases/latest | grep browser_download_url | cut -d '"' -f 4)"
+oxiderustlatestlink="$(curl -s https://api.github.com/repos/theumod/umod.rust/releases/latest | grep browser_download_url | cut -d '"' -f 4)"
 oxidehurtworldlatestlink="$(curl -s https://api.github.com/repos/OxideMod/Oxide.Hurtworld/releases/latest | grep browser_download_url | cut -d '"' -f 4 | grep "Oxide.Hurtworld.zip")"
 oxidesdtdlatestlink="$(curl -s https://api.github.com/repos/OxideMod/Oxide.SevenDaysToDie/releases/latest | grep browser_download_url | cut -d '"' -f 4)"
 

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -20,7 +20,7 @@ if [ -f ".dev-debug" ]; then
 	set -x
 fi
 
-version="180718"
+version="180908"
 shortname="core"
 gameservername="core"
 rootdir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"


### PR DESCRIPTION
The OxideMod/Oxide.Rust GitHub repository is now found under theumod/umod.rust.

This, of course, has caused Oxide update to fail, and is simply fixed by swapping the URL. The Hurtworld and SevenDaysToDie are still belonging to the OxideMod account, but it may also migrate later.

See: https://github.com/theumod/umod.rust