### PR TITLE
use branch name while checking for updates

### DIFF
--- a/lgsm/functions/update_steamcmd.sh
+++ b/lgsm/functions/update_steamcmd.sh
@@ -166,7 +166,7 @@ fn_update_steamcmd_check(){
 
 	# Gets availablebuild info
 	cd "${steamcmddir}" || exit
-	availablebuild=$(./steamcmd.sh +login "${steamuser}" "${steampass}" +app_info_update 1 +app_info_print "${appid}" +app_info_print "${appid}" +quit | sed -n '/branch/,$p' | grep -m 1 buildid | tr -cd '[:digit:]')
+	availablebuild=$(./steamcmd.sh +login "${steamuser}" "${steampass}" +app_info_update 1 +app_info_print "${appid}" +quit | sed '1,/branches/d' | sed "1,/${branchname}/d" | grep -m 1 buildid | tr -cd '[:digit:]')
 	if [ -z "${availablebuild}" ]; then
 		fn_print_fail "Checking for update: SteamCMD"
 		sleep 0.5


### PR DESCRIPTION
Should fix #1913 

With branch `-beta beta`:
```bash
$ ./stserver update
[  OK  ] Update stserver: Checking for update: SteamCMD: No update available

No update available:
	Current version: 3129892
	Available version: 3129892
	https://steamdb.info/app/600760/
```
Changed to `-beta public`
```bash
$ ./stserver update
[  OK  ] Update stserver: Checking for update: SteamCMD: Update available

Update available:
	Current build: 3129892
	Available build: 3126493
	https://steamdb.info/app/600760/

Applying update...
[  OK  ] Stopping stserver: Graceful: CTRL+c: 3: OK
[  OK  ] Update stserver: SteamCMD
Redirecting stderr to '/home/stserver/Steam/logs/stderr.txt'
[  0%] Checking for available updates...
[----] Verifying installation...
Steam Console Client (c) Valve Corporation
-- type 'quit' to exit --
Loading Steam API...OK.

Connecting anonymously to Steam Public...Logged in OK
Waiting for user info...
OK
 Update state (0x5) validating, progress: 0.00 (0 / 0)
 # ...
 Update state (0x61) downloading, progress: 99.64 (286495326 / 287543902)
Success! App '600760' fully installed.
[  OK  ] Starting stserver: LinuxGSM
[  OK  ] Alert stserver: Sending Discord alert
```
Back to `-beta beta`
```bash
$ ./stserver update
[  OK  ] Update stserver: Checking for update: SteamCMD: Update available

Update available:
	Current build: 3126493
	Available build: 3129892
	https://steamdb.info/app/600760/

Applying update...
[  OK  ] Stopping stserver: Graceful: CTRL+c: 2
# ...
```