### PR TITLE
Dependency checking can run as root

### DIFF
--- a/lgsm/functions/check.sh
+++ b/lgsm/functions/check.sh
@@ -10,7 +10,14 @@ local commandname="CHECK"
 # Every command that requires checks just references check.sh
 # check.sh selects which checks to run by using arrays
 
-check_root.sh
+local allowed_inputs_array=( install auto-install i ai )
+for allowed_input in "${allowed_inputs_array[@]}"
+do
+	if [ "${allowed_input}" != "${userinput}" ]; then
+		check_root.sh
+	fi
+done
+
 check_tmuxception.sh
 
 if [ "$(whoami)" != "root" ]; then

--- a/lgsm/functions/check.sh
+++ b/lgsm/functions/check.sh
@@ -13,8 +13,10 @@ local commandname="CHECK"
 check_root.sh
 check_tmuxception.sh
 
-if [ "${function_selfname}" != "command_monitor.sh" ]; then
-	check_permissions.sh
+if [ "$(whoami)" != "root" ]; then
+	if [ "${function_selfname}" != "command_monitor.sh" ]; then
+		check_permissions.sh
+	fi
 fi
 
 if [ "${function_selfname}" != "command_install.sh" ]&&[ "${function_selfname}" != "command_update_functions.sh" ]&&[ "${function_selfname}" != "command_update_linuxgsm.sh" ]&&[ "${function_selfname}" != "command_details.sh" ]&&[ "${function_selfname}" != "command_postdetails.sh" ]; then
@@ -29,13 +31,15 @@ do
 	fi
 done
 
-local allowed_commands_array=( command_debug.sh command_start.sh command_install.sh )
-for allowed_command in "${allowed_commands_array[@]}"
-do
-	if [ "${allowed_command}" == "${function_selfname}" ]; then
-		check_glibc.sh
-	fi
-done
+if [ "$(whoami)" != "root" ]; then
+	local allowed_commands_array=( command_debug.sh command_start.sh command_install.sh )
+	for allowed_command in "${allowed_commands_array[@]}"
+	do
+		if [ "${allowed_command}" == "${function_selfname}" ]; then
+			check_glibc.sh
+		fi
+	done
+fi
 
 local allowed_commands_array=( command_backup.sh command_console.sh command_debug.sh command_details.sh command_unreal2_maps.sh command_fastdl.sh command_mods_install.sh command_mods_remove.sh command_mods_update.sh command_monitor.sh command_postdetails.sh command_restart.sh command_start.sh command_stop.sh command_test_alert.sh command_ts3_server_pass.sh command_update.sh command_update_functions.sh command_validate.sh command_wipe.sh command_unreal2_maps.sh command_ut99maps.sh)
 for allowed_command in "${allowed_commands_array[@]}"

--- a/lgsm/functions/check.sh
+++ b/lgsm/functions/check.sh
@@ -10,7 +10,7 @@ local commandname="CHECK"
 # Every command that requires checks just references check.sh
 # check.sh selects which checks to run by using arrays
 
-if [ "${userinput}" != "install" ]||[ "${userinput}" != "auto-install" ]||[ "${userinput}" != "i" ]||[ "${userinput}" != "ai" ]; then
+if [ "${userinput}" != "install" ]&&[ "${userinput}" != "auto-install" ]&&[ "${userinput}" != "i" ]&&[ "${userinput}" != "ai" ]; then
 	check_root.sh
 fi
 

--- a/lgsm/functions/check.sh
+++ b/lgsm/functions/check.sh
@@ -13,7 +13,7 @@ local commandname="CHECK"
 local allowed_inputs_array=( install auto-install i ai )
 for allowed_input in "${allowed_inputs_array[@]}"
 do
-	if [ "${allowed_input}" != "${userinput}" ]; then
+	if [ "${allowed_input}" == "${userinput}" ]; then
 		check_root.sh
 	fi
 done

--- a/lgsm/functions/check.sh
+++ b/lgsm/functions/check.sh
@@ -10,7 +10,7 @@ local commandname="CHECK"
 # Every command that requires checks just references check.sh
 # check.sh selects which checks to run by using arrays
 
-if [ "${userinput}" == "install" ]||[ "${userinput}" == "auto-install" ]||[ "${userinput}" == "i" ]||[ "${userinput}" == "ai" ]; then
+if [ "${userinput}" != "install" ]||[ "${userinput}" != "auto-install" ]||[ "${userinput}" != "i" ]||[ "${userinput}" != "ai" ]; then
 	check_root.sh
 fi
 

--- a/lgsm/functions/check.sh
+++ b/lgsm/functions/check.sh
@@ -10,15 +10,9 @@ local commandname="CHECK"
 # Every command that requires checks just references check.sh
 # check.sh selects which checks to run by using arrays
 
-local allowed_inputs_array=( install auto-install i ai )
-for allowed_input in "${allowed_inputs_array[@]}"
-do
-	if [ "${allowed_input}" == "${userinput}" ]; then
-		break
-	else
-		check_root.sh
-	fi
-done
+if [ "${userinput}" == "install" ]||[ "${userinput}" == "auto-install" ]||[ "${userinput}" == "i" ]||[ "${userinput}" == "ai" ]; then
+	check_root.sh
+fi
 
 check_tmuxception.sh
 

--- a/lgsm/functions/check.sh
+++ b/lgsm/functions/check.sh
@@ -14,6 +14,8 @@ local allowed_inputs_array=( install auto-install i ai )
 for allowed_input in "${allowed_inputs_array[@]}"
 do
 	if [ "${allowed_input}" == "${userinput}" ]; then
+		break
+	else
 		check_root.sh
 	fi
 done

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -180,8 +180,8 @@ fn_deps_email(){
 fn_found_missing_deps(){
 	if [ "${#array_deps_missing[@]}" != "0" ]; then
 
-		fn_print_warning_nl "Checking dependencies: missing: ${red}${array_deps_missing[@]}${default}"
-		fn_script_log_warn "Checking dependencies: missing: ${array_deps_missing[@]}"
+		fn_print_warning_nl "Missing dependencies: ${red}${array_deps_missing[@]}${default}"
+		fn_script_log_warn "Missing dependencies: ${array_deps_missing[@]}"
 		sleep 0.5
 		if [ -n "${monostatus}" ]; then
 			fn_install_mono_repo
@@ -257,8 +257,8 @@ fn_found_missing_deps(){
 			sleep 5
 		fi
 	else
-		fn_print_information_nl "Checking dependencies: all dependencies already installed"
-		fn_script_log_error "Checking dependencies: all dependencies already installed"
+		fn_print_information_nl "Required dependencies already installed"
+		fn_script_log_info "Required dependencies already installed"
 	fi
 }
 

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -258,10 +258,6 @@ fn_found_missing_deps(){
 			sleep 5
 		fi
 	fi
-	# If running dependency check as root will remove any files that belong to root user.
-	if [ "$(whoami)" == "root" ]; then
-		find "${lgsmdir}" -group root -exec rm -rf "{}" \;
-	fi
 }
 
 fn_check_loop(){

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -482,9 +482,18 @@ fn_deps_build_redhat(){
 }
 
 if [ "${function_selfname}" == "command_install.sh" ]; then
-	echo ""
-	echo "Checking Dependencies"
-	echo "================================="
+	if [ "$(whoami)" == "root" ]; then
+		echo ""
+		echo "Checking Dependencies as root"
+		echo "================================="
+		fn_print_information_nl "Checking any missing dependencies for ${gamename} server only."
+		fn_print_information_nl "This will NOT install a ${gamename} server."
+		sleep 2
+	else
+		echo ""
+		echo "Checking Dependencies"
+		echo "================================="
+	fi
 fi
 
 # Filter checking in to Debian or Red Hat Based

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -178,9 +178,10 @@ fn_deps_email(){
 }
 
 fn_found_missing_deps(){
+	fn_print_dots "Checking dependencies"
+	sleep 0.5
 	if [ "${#array_deps_missing[@]}" != "0" ]; then
-		fn_print_dots "Checking dependencies"
-		sleep 0.5
+
 		fn_print_error_nl "Checking dependencies: missing: ${red}${array_deps_missing[@]}${default}"
 		fn_script_log_error "Checking dependencies: missing: ${array_deps_missing[@]}"
 		sleep 0.5
@@ -257,6 +258,9 @@ fn_found_missing_deps(){
 		if [ "${function_selfname}" == "command_install.sh" ]; then
 			sleep 5
 		fi
+	else
+		fn_print_ok_nl "Checking dependencies: all dependencies already installed"
+		fn_script_log_error "Checking dependencies: all dependencies already installed"
 	fi
 }
 

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -178,12 +178,10 @@ fn_deps_email(){
 }
 
 fn_found_missing_deps(){
-	fn_print_dots "Checking dependencies"
-	sleep 0.5
 	if [ "${#array_deps_missing[@]}" != "0" ]; then
 
-		fn_print_error_nl "Checking dependencies: missing: ${red}${array_deps_missing[@]}${default}"
-		fn_script_log_error "Checking dependencies: missing: ${array_deps_missing[@]}"
+		fn_print_warning_nl "Checking dependencies: missing: ${red}${array_deps_missing[@]}${default}"
+		fn_script_log_warn "Checking dependencies: missing: ${array_deps_missing[@]}"
 		sleep 0.5
 		if [ -n "${monostatus}" ]; then
 			fn_install_mono_repo
@@ -259,7 +257,7 @@ fn_found_missing_deps(){
 			sleep 5
 		fi
 	else
-		fn_print_ok_nl "Checking dependencies: all dependencies already installed"
+		fn_print_information_nl "Checking dependencies: all dependencies already installed"
 		fn_script_log_error "Checking dependencies: all dependencies already installed"
 	fi
 }

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -260,7 +260,7 @@ fn_found_missing_deps(){
 	fi
 	# If running dependency check as root will remove any files that belong to root user.
 	if [ "$(whoami)" == "root" ]; then
-		find "${lgsmdir}" -group root -exec rm -fr {} \;
+		find "${lgsmdir}" -group root -exec rm -rf "{}" \;
 	fi
 }
 

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -258,6 +258,10 @@ fn_found_missing_deps(){
 			sleep 5
 		fi
 	fi
+	# If running dependency check as root will remove any files that belong to root user.
+	if [ "$(whoami)" == "root" ]; then
+		find "${lgsmdir}" -group root -exec rm -fr {} \;
+	fi
 }
 
 fn_check_loop(){

--- a/lgsm/functions/check_permissions.sh
+++ b/lgsm/functions/check_permissions.sh
@@ -230,8 +230,10 @@ fn_sys_perm_error_process(){
 # Run perm error detect & fix/alert functions on /sys directories
 
 ## Run checks
-fn_check_ownership
-fn_check_permissions
-if [ "${function_selfname}" == "command_start.sh" ]; then
-	fn_sys_perm_error_process
+if [ "$(whoami)" != "root" ]; then
+	fn_check_ownership
+	fn_check_permissions
+	if [ "${function_selfname}" == "command_start.sh" ]; then
+		fn_sys_perm_error_process
+	fi
 fi

--- a/lgsm/functions/check_root.sh
+++ b/lgsm/functions/check_root.sh
@@ -8,9 +8,11 @@ local commandname="CHECK"
 local function_selfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 if [ "$(whoami)" = "root" ]; then
-	fn_print_fail_nl "Do NOT run this script as root!"
-	if [ -d "${lgsmlogdir}" ]; then
-		fn_script_log_fatal "${selfname} attempted to run as root."
+	if [ "${function_selfname}" != "command_install.sh" ]; then
+		fn_print_fail_nl "Do NOT run this script as root!"
+		if [ -d "${lgsmlogdir}" ]; then
+			fn_script_log_fatal "${selfname} attempted to run as root."
+		fi
+		core_exit.sh
 	fi
-	core_exit.sh
 fi

--- a/lgsm/functions/command_install.sh
+++ b/lgsm/functions/command_install.sh
@@ -10,37 +10,41 @@ local commandaction="Install"
 local function_selfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 check.sh
-install_header.sh
-install_server_dir.sh
-install_logs.sh
-check_deps.sh
-installflag=1
-# Download and install
-if [ "${gamename}" == "Unreal Tournament 2004" ]; then
-	install_server_files.sh
-	install_ut2k4_key.sh
-elif [ -z "${appid}" ]; then
-	installer=1
-	install_server_files.sh
-elif [ -n "${appid}" ]; then
-	install_steamcmd.sh
-	install_server_files.sh
-fi
+if [ "$(whoami)" = "root" ]; then
+	check_deps.sh
+else
+	install_header.sh
+	install_server_dir.sh
+	install_logs.sh
+	check_deps.sh
+	installflag=1
+	# Download and install
+	if [ "${gamename}" == "Unreal Tournament 2004" ]; then
+		install_server_files.sh
+		install_ut2k4_key.sh
+	elif [ -z "${appid}" ]; then
+		installer=1
+		install_server_files.sh
+	elif [ -n "${appid}" ]; then
+		install_steamcmd.sh
+		install_server_files.sh
+	fi
 
-# Configuration
-install_config.sh
-if [ "${gamename}" == "BrainBread 2" ]||[ "${gamename}" == "Black Mesa: Deathmatch" ]||[ "${gamename}" == "Counter-Strike: Global Offensive" ]||[ "${gamename}" == "Empires Mod" ]||[ "${gamename}" == "Garry’s Mod" ]||[ "${gamename}" == "No more Room in Hell" ]||[ "${gamename}" == "Team Fortress 2" ]||[ "${gamename}" == "Tower Unite" ]; then
-	install_gslt.sh
-elif [ "${gamename}" == "Don't Starve Together" ]; then
-	install_dst_token.sh
-elif [ "${gamename}" == "Squad" ]; then
-	install_squad_license.sh
-elif [ "${gamename}" == "TeamSpeak 3" ]; then
-	install_ts3db.sh
-elif [ "${gamename}" == "Multi Theft Auto" ]; then
-	command_install_resources_mta.sh
-fi
+	# Configuration
+	install_config.sh
+	if [ "${gamename}" == "BrainBread 2" ]||[ "${gamename}" == "Black Mesa: Deathmatch" ]||[ "${gamename}" == "Counter-Strike: Global Offensive" ]||[ "${gamename}" == "Empires Mod" ]||[ "${gamename}" == "Garry’s Mod" ]||[ "${gamename}" == "No more Room in Hell" ]||[ "${gamename}" == "Team Fortress 2" ]||[ "${gamename}" == "Tower Unite" ]; then
+		install_gslt.sh
+	elif [ "${gamename}" == "Don't Starve Together" ]; then
+		install_dst_token.sh
+	elif [ "${gamename}" == "Squad" ]; then
+		install_squad_license.sh
+	elif [ "${gamename}" == "TeamSpeak 3" ]; then
+		install_ts3db.sh
+	elif [ "${gamename}" == "Multi Theft Auto" ]; then
+		command_install_resources_mta.sh
+	fi
 
-fix.sh
-install_complete.sh
-core_exit.sh
+	fix.sh
+	install_complete.sh
+	core_exit.sh
+fi

--- a/lgsm/functions/core_exit.sh
+++ b/lgsm/functions/core_exit.sh
@@ -17,6 +17,7 @@ fn_exit_dev_debug(){
 # If running dependency check as root will remove any files that belong to root user.
 if [ "$(whoami)" == "root" ]; then
 	find "${lgsmdir}"/ -group root -prune -exec rm -rf {} +
+	find "${logdir}"/ -group root -prune -exec rm -rf {} +
 fi
 
 if [ -n "${exitbypass}" ]; then

--- a/lgsm/functions/core_exit.sh
+++ b/lgsm/functions/core_exit.sh
@@ -14,6 +14,11 @@ fn_exit_dev_debug(){
 	fi
 }
 
+# If running dependency check as root will remove any files that belong to root user.
+if [ "$(whoami)" == "root" ]; then
+	find "${lgsmdir}" -group root -exec rm -rf "{}" \;
+fi
+
 if [ -n "${exitbypass}" ]; then
 	unset exitbypass
 elif [ -n "${exitcode}" ]&&[ "${exitcode}" != "0" ]; then

--- a/lgsm/functions/core_exit.sh
+++ b/lgsm/functions/core_exit.sh
@@ -16,7 +16,7 @@ fn_exit_dev_debug(){
 
 # If running dependency check as root will remove any files that belong to root user.
 if [ "$(whoami)" == "root" ]; then
-	find "${lgsmdir}"/ -group root -prune -exec rm -rf {} \;
+	find "${lgsmdir}"/ -group root -prune -exec rm -rf {} +
 fi
 
 if [ -n "${exitbypass}" ]; then

--- a/lgsm/functions/core_exit.sh
+++ b/lgsm/functions/core_exit.sh
@@ -16,7 +16,7 @@ fn_exit_dev_debug(){
 
 # If running dependency check as root will remove any files that belong to root user.
 if [ "$(whoami)" == "root" ]; then
-	find "${lgsmdir}"/ -group root -exec rm -f {} \;
+	find "${lgsmdir}"/ -group root -exec rm -rf {} \;
 fi
 
 if [ -n "${exitbypass}" ]; then

--- a/lgsm/functions/core_exit.sh
+++ b/lgsm/functions/core_exit.sh
@@ -16,7 +16,7 @@ fn_exit_dev_debug(){
 
 # If running dependency check as root will remove any files that belong to root user.
 if [ "$(whoami)" == "root" ]; then
-	find "${lgsmdir}"/ -group root -exec rm -rf {} \;
+	find "${lgsmdir}"/ -group root -prune -exec rm -rf {} \;
 fi
 
 if [ -n "${exitbypass}" ]; then

--- a/lgsm/functions/core_exit.sh
+++ b/lgsm/functions/core_exit.sh
@@ -16,7 +16,7 @@ fn_exit_dev_debug(){
 
 # If running dependency check as root will remove any files that belong to root user.
 if [ "$(whoami)" == "root" ]; then
-	find "${lgsmdir}" -group root -exec rm -rf "{}" \;
+	find "${lgsmdir}"/ -group root -exec rm -f {} \;
 fi
 
 if [ -n "${exitbypass}" ]; then

--- a/lgsm/functions/core_exit.sh
+++ b/lgsm/functions/core_exit.sh
@@ -16,8 +16,8 @@ fn_exit_dev_debug(){
 
 # If running dependency check as root will remove any files that belong to root user.
 if [ "$(whoami)" == "root" ]; then
-	find "${lgsmdir}"/ -group root -prune -exec rm -rf {} +
-	find "${logdir}"/ -group root -prune -exec rm -rf {} +
+	find "${lgsmdir}"/ -group root -prune -exec rm -rf {} + > /dev/null 2>&1
+	find "${logdir}"/ -group root -prune -exec rm -rf {} + > /dev/null 2>&1
 fi
 
 if [ -n "${exitbypass}" ]; then

--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -174,13 +174,15 @@ if [ -z "${extip}" ]; then
 fi
 
 # Steam Master Server - checks if detected by master server
-if [ "${ip}" ] && [ "${port}" ]; then
-	if [ "${engine}" == "source" ]||[ "${engine}" == "goldsource" ]||[ "${shortname}" == "jc2" ]||[ "${shortname}" == "ql" ]; then
-		masterserver=$(${curlpath} -s 'https://api.steampowered.com/ISteamApps/GetServersAtAddress/v0001?addr='${ip}':'${port}'&format=json' | jq '.response.servers[]|.addr' | wc -l)
-		if [ "${steammaster}" == "1" ]; then
-			masterserver="true"
-		else
-			masterserver="false"
+if [ ! "$(command -v jq 2>/dev/null)" ]; then
+	if [ "${ip}" ] && [ "${port}" ]; then
+		if [ "${engine}" == "source" ]||[ "${engine}" == "goldsource" ]||[ "${shortname}" == "jc2" ]||[ "${shortname}" == "ql" ]; then
+			masterserver=$(${curlpath} -s 'https://api.steampowered.com/ISteamApps/GetServersAtAddress/v0001?addr='${ip}':'${port}'&format=json' | jq '.response.servers[]|.addr' | wc -l)
+			if [ "${steammaster}" == "1" ]; then
+				masterserver="true"
+			else
+				masterserver="false"
+			fi
 		fi
 	fi
 fi

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -258,7 +258,9 @@ fn_install_file(){
 # Prevent from running this script as root.
 if [ "$(whoami)" == "root" ]; then
 	if [ "${userinput}" == "install" ]||[ "${userinput}" == "auto-install" ]||[ "${userinput}" == "i" ]||[ "${userinput}" == "ai" ]; then
-		shortname="tf2server"
+		if [ "${shortname}" == "core" ]; then
+			shortname="core-dep"
+		fi
 	elif [ ! -f "${functionsdir}/core_functions.sh" ]||[ ! -f "${functionsdir}/check_root.sh" ]||[ ! -f "${functionsdir}/core_messages.sh" ]; then
 		echo "[ FAIL ] Do NOT run this script as root!"
 		exit 1
@@ -312,7 +314,7 @@ if [ "${shortname}" == "core" ]; then
 # LinuxGSM Server Mode
 else
 	core_functions.sh
-	if [ "$(whoami)" != "root" ]; then
+	if [ "${shortname}" != "core-dep" ]; then
 		# Load LinuxGSM configs
 		# These are required to get all the default variables for the specific server.
 		# Load the default config. If missing download it. If changed reload it.

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -38,6 +38,7 @@ tmpdir="${lgsmdir}/tmp"
 configdir="${lgsmdir}/config-lgsm"
 configdirserver="${configdir}/${gameservername}"
 configdirdefault="${lgsmdir}/config-default"
+userinput="${1}"
 
 ## GitHub Branch Select
 # Allows for the use of different function files
@@ -256,7 +257,9 @@ fn_install_file(){
 
 # Prevent from running this script as root.
 if [ "$(whoami)" == "root" ]; then
-	if [ ! -f "${functionsdir}/core_functions.sh" ]||[ ! -f "${functionsdir}/check_root.sh" ]||[ ! -f "${functionsdir}/core_messages.sh" ]; then
+	if [ "${userinput}" == "install" ]||[ "${userinput}" == "auto-install" ]||[ "${userinput}" == "i" ]||[ "${userinput}" == "ai" ]; then
+		shortname="tf2server"
+	elif [ ! -f "${functionsdir}/core_functions.sh" ]||[ ! -f "${functionsdir}/check_root.sh" ]||[ ! -f "${functionsdir}/core_messages.sh" ]; then
 		echo "[ FAIL ] Do NOT run this script as root!"
 		exit 1
 	else
@@ -267,7 +270,6 @@ fi
 
 # LinuxGSM installer mode
 if [ "${shortname}" == "core" ]; then
-	userinput=$1
 	datadir="${tmpdir}/data"
 	serverlist="${datadir}/serverlist.csv"
 
@@ -310,29 +312,16 @@ if [ "${shortname}" == "core" ]; then
 # LinuxGSM Server Mode
 else
 	core_functions.sh
-
-	# Load LinuxGSM configs
-	# These are required to get all the default variables for the specific server.
-	# Load the default config. If missing download it. If changed reload it.
-	if [ ! -f "${configdirdefault}/config-lgsm/${gameservername}/_default.cfg" ]; then
-		mkdir -p "${configdirdefault}/config-lgsm/${gameservername}"
-		fn_fetch_config "lgsm/config-default/config-lgsm/${gameservername}" "_default.cfg" "${configdirdefault}/config-lgsm/${gameservername}" "_default.cfg" "nochmodx" "norun" "noforcedl" "nomd5"
-	fi
-	if [ ! -f "${configdirserver}/_default.cfg" ]; then
-		mkdir -p "${configdirserver}"
-		echo -ne "    copying _default.cfg...\c"
-		cp -R "${configdirdefault}/config-lgsm/${gameservername}/_default.cfg" "${configdirserver}/_default.cfg"
-		exitcode=$?
-		if [ ${exitcode} -ne 0 ]; then
-			echo -e "FAIL"
-			exit 1
-		else
-			echo -e "OK"
+	if [ "$(whoami)" != "root" ]; then
+		# Load LinuxGSM configs
+		# These are required to get all the default variables for the specific server.
+		# Load the default config. If missing download it. If changed reload it.
+		if [ ! -f "${configdirdefault}/config-lgsm/${gameservername}/_default.cfg" ]; then
+			mkdir -p "${configdirdefault}/config-lgsm/${gameservername}"
+			fn_fetch_config "lgsm/config-default/config-lgsm/${gameservername}" "_default.cfg" "${configdirdefault}/config-lgsm/${gameservername}" "_default.cfg" "nochmodx" "norun" "noforcedl" "nomd5"
 		fi
-	else
-		function_file_diff=$(diff -q "${configdirdefault}/config-lgsm/${gameservername}/_default.cfg" "${configdirserver}/_default.cfg")
-		if [ "${function_file_diff}" != "" ]; then
-			fn_print_warn_nl "_default.cfg has been altered. reloading config."
+		if [ ! -f "${configdirserver}/_default.cfg" ]; then
+			mkdir -p "${configdirserver}"
 			echo -ne "    copying _default.cfg...\c"
 			cp -R "${configdirdefault}/config-lgsm/${gameservername}/_default.cfg" "${configdirserver}/_default.cfg"
 			exitcode=$?
@@ -342,27 +331,41 @@ else
 			else
 				echo -e "OK"
 			fi
+		else
+			function_file_diff=$(diff -q "${configdirdefault}/config-lgsm/${gameservername}/_default.cfg" "${configdirserver}/_default.cfg")
+			if [ "${function_file_diff}" != "" ]; then
+				fn_print_warn_nl "_default.cfg has been altered. reloading config."
+				echo -ne "    copying _default.cfg...\c"
+				cp -R "${configdirdefault}/config-lgsm/${gameservername}/_default.cfg" "${configdirserver}/_default.cfg"
+				exitcode=$?
+				if [ ${exitcode} -ne 0 ]; then
+					echo -e "FAIL"
+					exit 1
+				else
+					echo -e "OK"
+				fi
+			fi
 		fi
-	fi
-	source "${configdirserver}/_default.cfg"
-	# Load the common.cfg config. If missing download it
-	if [ ! -f "${configdirserver}/common.cfg" ]; then
-		fn_fetch_config "lgsm/config-default/config-lgsm" "common-template.cfg" "${configdirserver}" "common.cfg" "${chmodx}" "nochmodx" "norun" "noforcedl" "nomd5"
-		source "${configdirserver}/common.cfg"
-	else
-		source "${configdirserver}/common.cfg"
-	fi
-	# Load the instance.cfg config. If missing download it
-	if [ ! -f "${configdirserver}/${servicename}.cfg" ]; then
-		fn_fetch_config "lgsm/config-default/config-lgsm" "instance-template.cfg" "${configdirserver}" "${servicename}.cfg" "nochmodx" "norun" "noforcedl" "nomd5"
-		source "${configdirserver}/${servicename}.cfg"
-	else
-		source "${configdirserver}/${servicename}.cfg"
-	fi
+		source "${configdirserver}/_default.cfg"
+		# Load the common.cfg config. If missing download it
+		if [ ! -f "${configdirserver}/common.cfg" ]; then
+			fn_fetch_config "lgsm/config-default/config-lgsm" "common-template.cfg" "${configdirserver}" "common.cfg" "${chmodx}" "nochmodx" "norun" "noforcedl" "nomd5"
+			source "${configdirserver}/common.cfg"
+		else
+			source "${configdirserver}/common.cfg"
+		fi
+		# Load the instance.cfg config. If missing download it
+		if [ ! -f "${configdirserver}/${servicename}.cfg" ]; then
+			fn_fetch_config "lgsm/config-default/config-lgsm" "instance-template.cfg" "${configdirserver}" "${servicename}.cfg" "nochmodx" "norun" "noforcedl" "nomd5"
+			source "${configdirserver}/${servicename}.cfg"
+		else
+			source "${configdirserver}/${servicename}.cfg"
+		fi
 
-	# Load the linuxgsm.sh in to tmpdir. If missing download it
-	if [ ! -f "${tmpdir}/linuxgsm.sh" ]; then
-		fn_fetch_file_github "" "linuxgsm.sh" "${tmpdir}" "chmodx" "norun" "noforcedl" "nomd5"
+		# Load the linuxgsm.sh in to tmpdir. If missing download it
+		if [ ! -f "${tmpdir}/linuxgsm.sh" ]; then
+			fn_fetch_file_github "" "linuxgsm.sh" "${tmpdir}" "chmodx" "norun" "noforcedl" "nomd5"
+		fi
 	fi
 	# Enables ANSI colours from core_messages.sh. Can be disabled with ansi=off
 	fn_ansi_loader

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -20,7 +20,7 @@ if [ -f ".dev-debug" ]; then
 	set -x
 fi
 
-version="180908"
+version="181007"
 shortname="core"
 gameservername="core"
 rootdir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
@@ -255,11 +255,12 @@ fn_install_file(){
 	exit
 }
 
-# Prevent from running this script as root.
+# Prevent LinuxGSM from running as root. Except if doing a dependency install.
 if [ "$(whoami)" == "root" ]; then
 	if [ "${userinput}" == "install" ]||[ "${userinput}" == "auto-install" ]||[ "${userinput}" == "i" ]||[ "${userinput}" == "ai" ]; then
 		if [ "${shortname}" == "core" ]; then
-			shortname="core-dep"
+			echo "[ FAIL ] Do NOT run this script as root!"
+			exit 1
 		fi
 	elif [ ! -f "${functionsdir}/core_functions.sh" ]||[ ! -f "${functionsdir}/check_root.sh" ]||[ ! -f "${functionsdir}/core_messages.sh" ]; then
 		echo "[ FAIL ] Do NOT run this script as root!"


### PR DESCRIPTION
dependency checks can now run as root in "server mode" e.g `./csgoserver install` run as root will trigger dependency checking only. Allowing users to install dependencies using LinuxGSM. This will be very useful for automated installations of LinuxGSM