### PR TITLE
Added map variable for ARK

### DIFF
--- a/lgsm/config-default/config-lgsm/arkserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arkserver/_default.cfg
@@ -13,11 +13,12 @@ ip="0.0.0.0"
 port="7777"
 queryport="27015"
 rconport="27020"
+defaultmap="TheIsland"
 maxplayers="70"
 
 ## Server Start Command | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters#additional-parameters
 fn_parms(){
-parms="\"TheIsland?listen?MultiHome=${ip}?MaxPlayers=${maxplayers}?QueryPort=${queryport}?RCONPort=${rconport}?Port=${port}?\""
+parms="\"${defaultmap}?listen?MultiHome=${ip}?MaxPlayers=${maxplayers}?QueryPort=${queryport}?RCONPort=${rconport}?Port=${port}?\""
 }
 
 #### LinuxGSM Settings ####


### PR DESCRIPTION
I wouldn't put all available maps in there because we didn't do that for other games. I'm going to list them at https://github.com/GameServerManagers/LinuxGSM/wiki/Ark-Survival-Evolved

And I wouldn't add that second option "AltSaveDirectoryName" because it could be confusing for current users. You can still add it yourself though..

Just a very simple but useful change.

Closes #1965