### PR TITLE
Add some default mapgroup examples to csgoserver

### DIFF
--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -10,14 +10,14 @@
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 # https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive_Dedicated_Servers#Starting_the_Server
-# [Game Modes]			  gametype	gamemode	mapgroup (you can mix these across Game Modes, but use only one)
-# Arms Race           1         0         mg_armsrace
-# Classic Casual		  0			    0			    mg_casualsigma, mg_casualdelta
-# Classic Competitive	0			    1		      mg_active, mg_reserves, mg_hostage, mg_de_dust2
-# Custom				      3			    0			
-# Deathmatch			    1			    2			    mg_deathmatch
-# Demolition			    1			    1			    mg_demolition
-# Wingman				      0			    2			
+# [Game Modes]			gametype	gamemode	mapgroup (you can mix these across Game Modes, but use only one)
+# Arms Race				1			0			mg_armsrace
+# Classic Casual		0			0			mg_casualsigma, mg_casualdelta
+# Classic Competitive	0			1			mg_active, mg_reserves, mg_hostage, mg_de_dust2
+# Custom				3			0
+# Deathmatch			1			2			mg_deathmatch
+# Demolition			1			1			mg_demolition
+# Wingman				0			2			
 gametype="0"
 gamemode="0"
 mapgroup="mg_active"

--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -10,14 +10,14 @@
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 # https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive_Dedicated_Servers#Starting_the_Server
-# [Game Modes]			gametype	gamemode	mapgroup (you can mix these across Game Modes, but use only one)
-# Arms Race				1			0			mg_armsrace
-# Classic Casual		0			0			mg_casualsigma, mg_casualdelta
-# Classic Competitive	0			1			mg_active, mg_reserves, mg_hostage, mg_de_dust2
-# Custom				3			0			
-# Deathmatch			1			2			mg_deathmatch
-# Demolition			1			1			mg_demolition
-# Wingman				0			2			
+# [Game Modes]			  gametype	gamemode	mapgroup (you can mix these across Game Modes, but use only one)
+# Arms Race           1         0         mg_armsrace
+# Classic Casual		  0			    0			    mg_casualsigma, mg_casualdelta
+# Classic Competitive	0			    1		      mg_active, mg_reserves, mg_hostage, mg_de_dust2
+# Custom				      3			    0			
+# Deathmatch			    1			    2			    mg_deathmatch
+# Demolition			    1			    1			    mg_demolition
+# Wingman				      0			    2			
 gametype="0"
 gamemode="0"
 mapgroup="mg_active"

--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -10,14 +10,14 @@
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 # https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive_Dedicated_Servers#Starting_the_Server
-# [Game Modes]			gametype	gamemode    mapgroup (you can mix these across Game Modes, but use only one)
-# Arms Race				1			0           mg_armsrace
-# Classic Casual		0			0           mg_casualsigma, mg_casualdelta
-# Classic Competitive	0			1           mg_active, mg_reserves, mg_hostage, mg_de_dust2
-# Custom				3			0           
-# Deathmatch			1			2           mg_deathmatch
-# Demolition			1			1           mg_demolition
-# Wingman				0			2           
+# [Game Modes]			gametype	gamemode	mapgroup (you can mix these across Game Modes, but use only one)
+# Arms Race				1			0			mg_armsrace
+# Classic Casual		0			0			mg_casualsigma, mg_casualdelta
+# Classic Competitive	0			1			mg_active, mg_reserves, mg_hostage, mg_de_dust2
+# Custom				3			0			
+# Deathmatch			1			2			mg_deathmatch
+# Demolition			1			1			mg_demolition
+# Wingman				0			2			
 gametype="0"
 gamemode="0"
 mapgroup="mg_active"

--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -10,14 +10,14 @@
 
 ## Server Start Settings | https://github.com/GameServerManagers/LinuxGSM/wiki/Start-Parameters
 # https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive_Dedicated_Servers#Starting_the_Server
-# [Game Modes]			gametype	gamemode
-# Arms Race				1			0
-# Classic Casual		0			0
-# Classic Competitive	0			1
-# Custom				3			0
-# Deathmatch			1			2
-# Demolition			1			1
-# Wingman				0			2
+# [Game Modes]			gametype	gamemode    mapgroup (you can mix these across Game Modes, but use only one)
+# Arms Race				1			0           mg_armsrace
+# Classic Casual		0			0           mg_casualsigma, mg_casualdelta
+# Classic Competitive	0			1           mg_active, mg_reserves, mg_hostage, mg_de_dust2
+# Custom				3			0           
+# Deathmatch			1			2           mg_deathmatch
+# Demolition			1			1           mg_demolition
+# Wingman				0			2           
 gametype="0"
 gamemode="0"
 mapgroup="mg_active"


### PR DESCRIPTION
There is no default specific mapgroup for Custom and Wingman.