### PR TITLE
deprecate: workshop fix that is no longer necessary

### DIFF
--- a/lgsm/functions/fix_csgo.sh
+++ b/lgsm/functions/fix_csgo.sh
@@ -32,14 +32,3 @@ if [ -f "${servercfgdir}/valve.rc" ] && grep -E '^\s*exec\s*(default|joystick)\.
 	sed -i 's/^\s*exec\s*joystick.cfg/\/\/exec joystick.cfg/g' "${servercfgdir}/valve.rc" > /dev/null 2>&1
 	fn_fix_msg_end
 fi
-
-# Fixes: workshop map issue.
-# http://forums.steampowered.com/forums/showthread.php?t=3170366.
-if [ -f "${systemdir}/subscribed_collection_ids.txt" ]||[ -f "${systemdir}/subscribed_file_ids.txt" ]||[ -f "${systemdir}/ugc_collection_cache.txt" ]; then
-	fixname="workshop map"
-	fn_fix_msg_start
-	rm -f "${systemdir}/subscribed_collection_ids.txt"
-	rm -f "${systemdir}/subscribed_file_ids.txt"
-	rm -f "${systemdir}/ugc_collection_cache.txt"
-	fn_fix_msg_end
-fi


### PR DESCRIPTION
# Description

The removed code was once required to fix an issue with CSGO workshop files. The removed code is no longer needed and is now an inconvenience rather than a convenience. At CSGO's current state, having LGSM delete workshop files would be a bug.

Thanks for everything. I love the script.

fixes #2188

## Type of change

* [x] Bug fix (non breaking change which fixes an issue)
* [ ] New feature (non breaking change which adds functionality)
* [ ] Refactor (non breaking change restructures existing code)
* [ ] This change requires a documentation update

## Checklist

* [x] My code follows the style guidelines of this project
* [x] This pull request links to an issue
* [x] I have performed a self review of my own code
* [x] I have commented my code, particularly in hard to understand areas
* [x] I have made corresponding changes to the documentation