### PR TITLE
fix(ts3server): correct ts3server config file name in comment

### DIFF
--- a/lgsm/config-default/config-lgsm/ts3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ts3server/_default.cfg
@@ -7,7 +7,7 @@
 # [instance].cfg - applies settings to a specific instance
 
 ## Server Start Settings | https://docs.linuxgsm.com/configuration/start-parameters
-# Edit serverfiles/ts3-server.ini after installation
+# Edit serverfiles/ts3server.ini after installation
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
# Description

It's `ts3server.ini`, not `ts3-server.ini`
It's only in the comment, not in actual code.

## Type of change

* [x] Bug fix (change which fixes an issue)
* [ ] New feature (change which adds functionality)
* [ ] New Server (new server added)
* [ ] Refactor (restructures existing code)
* [ ] This change requires a documentation update

## Checklist

* [x] My code follows the style guidelines of this project
* [ ] This pull request links to an issue
* [x] This pull request uses the `develop` branch as its base 
* [x] I have performed a self-review of my own code
* [ ] I have squashed commits
* [ ] I have commented my code, particularly in hard to understand areas
* [ ] I have made corresponding changes to the documentation if required
