### PR TITLE
Update _default.cfg

### DIFF
--- a/lgsm/config-default/config-lgsm/inssserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/inssserver/_default.cfg
@@ -23,7 +23,7 @@ maxplayers="28"
 fn_parms(){
 	# Allows serverpassword to work with parameters
 	if [ "${serverpassword}" != "NOT SET" ]; then
-		parms="${defaultmap}?Scenario=${defaultscenario}?MaxPlayers=${maxplayers}?Port=${port}?QueryPort=${queryport}?password="${serverpassword}" -hostname="${servername}" -log"
+		parms="${defaultmap}?Scenario=${defaultscenario}?MaxPlayers=${maxplayers}?Port=${port}?QueryPort=${queryport}?password="${serverpassword}" -hostname='${servername}' -log"
 	else
 		parms="${defaultmap}?Scenario=${defaultscenario}?MaxPlayers=${maxplayers}?Port=${port}?QueryPort=${queryport} -hostname='${servername}' -log"
 	fi


### PR DESCRIPTION
# Description

-hostname="${servername}" should be -hostname='${servername}'
When applying the wrong quotes, spaces are not detected and the server name will be cut off after the first space and showing incorrectly in the server browser.

fixes #2214

## Type of change

* [x] Bug fix (change which fixes an issue)
* [ ] New feature (change which adds functionality)
* [ ] New Server (new server added)
* [ ] Refactor (restructures existing code)
* [ ] This change requires a documentation update

## Checklist

* [x] My code follows the style guidelines of this project
* [x] This pull request links to an issue
* [x] This pull request uses the `develop` branch as its base 
* [x] I have performed a self-review of my own code
* [ ] I have squashed commits
* [ ] I have commented my code, particularly in hard to understand areas
* [ ] I have made corresponding changes to the documentation if required