### PR TITLE
corrected the fastdl command documentation link

### DIFF
--- a/lgsm/functions/command_fastdl.sh
+++ b/lgsm/functions/command_fastdl.sh
@@ -31,7 +31,7 @@ fi
 
 # Header
 fn_print_header
-echo "More info: https://git.io/vyk9a"
+echo "More info: https://docs.linuxgsm.com/commands/fastdl"
 echo ""
 
 # Prompts user for FastDL creation settings


### PR DESCRIPTION
# Description

I have changed the documentation link inside of the fastdl command from the GitHub Wiki to the correct page on https://docs.linuxgsm.com/. 

Fixes #2234 

## Type of change

* [x] Bug fix (change which fixes an issue)
* [ ] New feature (change which adds functionality)
* [ ] New Server (new server added)
* [ ] Refactor (restructures existing code)
* [ ] This change requires a documentation update

## Checklist

* [ ] My code follows the style guidelines of this project
* [ ] This pull request links to an issue
* [ ] This pull request uses the `develop` branch as its base 
* [ ] I have performed a self-review of my own code
* [ ] I have squashed commits
* [ ] I have commented my code, particularly in hard to understand areas
* [ ] I have made corresponding changes to the documentation if required
