### PR TITLE
Add debug option for Quake engine

### DIFF
--- a/lgsm/functions/command_debug.sh
+++ b/lgsm/functions/command_debug.sh
@@ -104,6 +104,8 @@ elif [ "${engine}" == "realvirtuality" ]; then
 	# be escaped for regular (tmux) loading, but need to be
 	# stripped when loading straight from the console.
 	${executable} ${parms//\\;/;}
+elif [ "${engine}" == "quake" ]; then
+    ${executable} ${parms} -condebug
 else
 	${executable} ${parms}
 fi


### PR DESCRIPTION
# Description

the quake engine have build-in debug function, when enabled by parameter it would generate a file called "Qconsole.log" which contain some useful information 

Fixes #2300 

## Type of change

* [ ] Bug fix (change which fixes an issue)
* [x] New feature (change which adds functionality)
* [ ] New Server (new server added)
* [ ] Refactor (restructures existing code)
* [ ] This change requires a documentation update

## Checklist

* [ ] My code follows the style guidelines of this project
* [ ] This pull request links to an issue
* [x] This pull request uses the `develop` branch as its base 
* [ ] I have performed a self-review of my own code
* [ ] I have squashed commits
* [ ] I have commented my code, particularly in hard to understand areas
* [ ] I have made corresponding changes to the documentation if required
