### PR TITLE
Add SVG support to FastDL

### DIFF
--- a/lgsm/functions/command_fastdl.sh
+++ b/lgsm/functions/command_fastdl.sh
@@ -154,7 +154,7 @@ fn_fastdl_preview(){
 	# Garry's Mod
 	if [ "${shortname}" == "gmod" ]; then
 		cd "${systemdir}" || exit
-		allowed_extentions_array=( "*.ain" "*.bsp" "*.mdl" "*.mp3" "*.ogg" "*.otf" "*.pcf" "*.phy" "*.png" "*.vtf" "*.vmt" "*.vtx" "*.vvd" "*.ttf" "*.wav" )
+		allowed_extentions_array=( "*.ain" "*.bsp" "*.mdl" "*.mp3" "*.ogg" "*.otf" "*.pcf" "*.phy" "*.png" "*.svg" "*.vtf" "*.vmt" "*.vtx" "*.vvd" "*.ttf" "*.wav" )
 		for allowed_extention in "${allowed_extentions_array[@]}"; do
 			fileswc=0
 			tput sc

--- a/lgsm/functions/command_fastdl.sh
+++ b/lgsm/functions/command_fastdl.sh
@@ -176,7 +176,7 @@ fn_fastdl_preview(){
 				if [ "${directory}" == "maps" ]; then
 					local allowed_extentions_array=( "*.bsp" "*.ain" "*.nav" "*.jpg" "*.txt" )
 				elif [ "${directory}" == "materials" ]; then
-					local allowed_extentions_array=( "*.vtf" "*.vmt" "*.vbf" )
+					local allowed_extentions_array=( "*.vtf" "*.vmt" "*.vbf" "*.png" "*.svg" )
 				elif [ "${directory}" == "models" ]; then
 					local allowed_extentions_array=( "*.vtx" "*.vvd" "*.mdl" "*.phy" "*.jpg" "*.png" )
 				elif [ "${directory}" == "particles" ]; then
@@ -315,7 +315,7 @@ fn_fastdl_source(){
 			if [ "${directory}" == "maps" ]; then
 				local allowed_extentions_array=( "*.bsp" "*.ain" "*.nav" "*.jpg" "*.txt" )
 			elif [ "${directory}" == "materials" ]; then
-				local allowed_extentions_array=( "*.vtf" "*.vmt" "*.vbf" )
+				local allowed_extentions_array=( "*.vtf" "*.vmt" "*.vbf" "*.png" "*.svg" )
 			elif [ "${directory}" == "models" ]; then
 				local allowed_extentions_array=( "*.vtx" "*.vvd" "*.mdl" "*.phy" "*.jpg" "*.png" )
 			elif [ "${directory}" == "particles" ]; then


### PR DESCRIPTION
# Description

CS:GO with Panorama now supports SVG custom logos, which are displayed in more places than a PNG logo.

Fixes #2297

Edit: unfortunately it's not working for logos out-of-the-box, because the FastDL directory must be the same as in the CS:GO directory structure, so you have to manually create the folders and copy your logo files there.

Bonus:
Extend materials with .png support.

## Type of change

* [ ] Bug fix (change which fixes an issue)
* [x] New feature (change which adds functionality)
* [ ] New Server (new server added)
* [ ] Refactor (restructures existing code)
* [x] This change requires a documentation update

## Checklist

* [x] My code follows the style guidelines of this project
* [x] This pull request links to an issue
* [x] This pull request uses the `develop` branch as its base 
* [x] I have performed a self-review of my own code
* [ ] I have squashed commits
* [ ] I have commented my code, particularly in hard to understand areas
* [x] I have made corresponding changes to the documentation if required
