### PR TITLE
Fix Teeworlds config location

### DIFF
--- a/lgsm/config-default/config-lgsm/twserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/twserver/_default.cfg
@@ -17,7 +17,7 @@ ip="0.0.0.0"
 
 ## Server Start Command | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
 fn_parms(){
-parms="-f ${servercfgfullpath}"
+parms="-f ${servercfg}"
 }
 
 #### LinuxGSM Settings ####
@@ -108,7 +108,7 @@ executabledir="${systemdir}"
 executable="./teeworlds_srv"
 servercfg="${servicename}.cfg" # Teeworlds can also auto load any config if an autoexec.cfg file is present in the server dir
 servercfgdefault="server.cfg"
-servercfgdir="${serverfiles}"
+servercfgdir="${serverfiles}/tw"
 servercfgfullpath="${servercfgdir}/${servercfg}"
 
 ## Backup Directory


### PR DESCRIPTION
# Description

Teeworlds now only allow relative path for config file location, absolute path are not allowed. and config files must placed in same directory as game server binaries. 

This is the only workaround i found after various experiments, existing installation must move config files from /serverfiles directory to /serverfiles/tw (which should affect very few, if any existing installations, as it would be discovered earlier when existing servers updates)

Fixes #2311

## Type of change

* [x] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, etc).
* [ ] This change requires a documentation update.

## Checklist

* [ ] This code follows the style guidelines of this project.
* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [ ] I have provided Co-author details below.
* [ ] I have performed a self-review of my own code.
* [ ] I have squashed commits.
* [ ] I have commented my code, particularly in hard to understand areas.
* [ ] I have made corresponding changes to the documentation if required.

## Provide Github Email

Fill out below info or tick box below:
```
Co-authored-by: Frisa <digimoncn@gmail.com>
```

- [ ] I do not wish to provide an email. I am aware this will hide me as the author of this commit.


All pull requests will now be squashed to create a tidy commit history and simplify changelog creation. You can provide either your own email or a GitHub-provided no-reply email.

When a PR is squashed the author becomes the person who squashed the PR. This removes you as the author of your own PR.
The only workaround for this is to add your details as a co-author. More info about co-authors can be found [here](https://help.github.com/en/articles/creating-a-commit-with-multiple-authors).
