### PR TITLE
Unnecessary FreeForAll info, add map hint to Danger Zone, indent mod

### DIFF
--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -10,15 +10,15 @@
 
 ## Server Start Settings | https://docs.linuxgsm.com/configuration/start-parameters
 # https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive_Dedicated_Servers#Starting_the_Server
-# [Game Modes]					gametype	gamemode	mapgroup (you can mix these across Game Modes, but use only one)
-# Arms Race						1			0			mg_armsrace
-# Classic Casual				0			0			mg_casualsigma, mg_casualdelta
-# Classic Competitive			0			1			mg_active, mg_reserves, mg_hostage, mg_de_dust2
-# Custom						3			0
-# Deathmatch					1			2			mg_deathmatch
-# Demolition					1			1			mg_demolition
-# Wingman						0			2			
-# Danger Zone (FreeForAll)		6			0			mg_dz_blacksite
+# [Game Modes]			gametype	gamemode	mapgroup (you can mix these across Game Modes, but use only one)
+# Arms Race				1			0			mg_armsrace
+# Classic Casual		0			0			mg_casualsigma, mg_casualdelta
+# Classic Competitive	0			1			mg_active, mg_reserves, mg_hostage, mg_de_dust2
+# Custom				3			0
+# Deathmatch			1			2			mg_deathmatch
+# Demolition			1			1			mg_demolition
+# Wingman				0			2			
+# Danger Zone			6			0			mg_dz_blacksite (map: dz_blacksite)
 gametype="0"
 gamemode="0"
 mapgroup="mg_active"


### PR DESCRIPTION
# Description

- no need for `FreeForAll` text for Danger Zone
- add map hint to Danger Zone (only map that can be used with this gamemode at the moment)
- and some indentation fix

## Type of change

* [ ] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [x] Comment update (typo, spelling, etc).
* [ ] This change requires a documentation update.

## Checklist

* [x] This code follows the style guidelines of this project.
* [ ] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] I have provided Co-author details below.
* [x] I have performed a self-review of my own code.
* [ ] I have squashed commits.
* [ ] I have commented my code, particularly in hard to understand areas.
* [ ] I have made corresponding changes to the documentation if required.

## Provide Github Email

```
Co-authored-by: Borzák Attila <1230402+borzaka@users.noreply.github.com>
```

- [ ] I do not wish to provide an email. I am aware this will hide me as the author of this commit.