### PR TITLE
remove the parameter that disable VAC

### DIFF
--- a/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
@@ -23,7 +23,7 @@ gslt=""
 
 ## Server Start Command | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
 fn_parms(){
-parms="-game nmrih -insecure -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} +map ${defaultmap} +sv_setsteamaccount ${gslt} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
+parms="-game nmrih -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} +map ${defaultmap} +sv_setsteamaccount ${gslt} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
 }
 
 #### LinuxGSM Settings ####


### PR DESCRIPTION
# Description

Enable VAC for NMRIH by default

Fixes #2325

## Type of change

* [x] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, etc).
* [ ] This change requires a documentation update.

## Checklist

* [ ] This code follows the style guidelines of this project.
* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [ ] I have provided Co-author details below.
* [ ] I have performed a self-review of my own code.
* [ ] I have squashed commits.
* [ ] I have commented my code, particularly in hard to understand areas.
* [ ] I have made corresponding changes to the documentation if required.

## Provide Github Email

Fill out below info or tick box below:
```
Co-authored-by: Frisa <digimoncn@gmail.com>
```

- [ ] I do not wish to provide an email. I am aware this will hide me as the author of this commit.


All pull requests will now be squashed to create a tidy commit history and simplify changelog creation. You can provide either your own email or a GitHub-provided no-reply email.

When a PR is squashed the author becomes the person who squashed the PR. This removes you as the author of your own PR.
The only workaround for this is to add your details as a co-author. More info about co-authors can be found [here](https://help.github.com/en/articles/creating-a-commit-with-multiple-authors).
