### PR TITLE
feat(config): standardise 32/64 bit binary selection

### DIFF
--- a/lgsm/config-default/config-lgsm/hwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hwserver/_default.cfg
@@ -25,8 +25,6 @@ admins=""
 ## Advanced Server Start Settings
 # Rollback server state (remove after start command)
 loadsave=""
-# Use unstable 64 bit server executable (O/1)
-x64mode="0"
 
 ## Server Start Command | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
 # Edit with care | http://hurtworld.wikia.com/wiki/Hosting_A_Server
@@ -119,11 +117,7 @@ engine="unity3d"
 ## Server Specific Directories
 systemdir="${serverfiles}"
 executabledir="${serverfiles}"
-if [ "${x64mode}" == "1" ]; then
-	executable="./Hurtworld.x86_64"
-else
-	executable="./Hurtworld.x86"
-fi
+executable=$([ "$(uname -m)" == "x86_64" ] && echo "./Hurtworld.x86_64" || echo "./Hurtworld.x86")
 
 ## Backup Directory
 backupdir="${rootdir}/backups"
@@ -143,4 +137,3 @@ postdetailslog="${lgsmlogdir}/${servicename}-postdetails.log"
 gamelogdate="${gamelogdir}/${servicename}-game-$(date '+%Y-%m-%d-%H:%M:%S').log"
 lgsmlogdate="${lgsmlogdir}/${servicename}-script-$(date '+%Y-%m-%d-%H:%M:%S').log"
 consolelogdate="${consolelogdir}/${servicename}-console-$(date '+%Y-%m-%d-%H:%M:%S').log"
-

--- a/lgsm/config-default/config-lgsm/qlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qlserver/_default.cfg
@@ -8,12 +8,9 @@
 
 #### Server Settings ####
 
-## Server Start Settings | https://docs.linuxgsm.com/configuration/start-parameters
-arch="x64" # x64 or x86
-
 ## Server Start Command | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
 # Edit with care | Install/Config Guide : https://steamcommunity.com/sharedfiles/filedetails/?id=542966946
-# Console Commands : http://www.regurge.at/ql/
+# Console Commands : http://www.regurge.at/ql
 fn_parms(){
 parms="+exec ${servercfg}"
 }

--- a/lgsm/config-default/config-lgsm/qlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qlserver/_default.cfg
@@ -103,7 +103,7 @@ engine="idtech3_ql"
 ## Server Specific Directories
 systemdir="${serverfiles}"
 executabledir="${serverfiles}"
-executable=$([ "${arch}" == 'x64' ] && echo "./run_server_x64.sh" || echo "./run_server_x86.sh")
+executable=$([ "$(uname -m)" == "x86_64" ] && echo "./run_server_x64.sh" || echo "./run_server_x86.sh")
 servercfg="${servicename}.cfg"
 servercfgdefault="server.cfg"
 servercfgdir="${serverfiles}/baseq3"

--- a/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
@@ -101,11 +101,7 @@ engine="unity3d"
 ## Server Specific Directories
 systemdir="${serverfiles}"
 executabledir="${serverfiles}"
-if [ "$(uname -m)" == "x86_64" ]; then
-	executable="./7DaysToDieServer.x86_64" 
-else
-	executable="./7DaysToDieServer.x86"
-fi	
+executable=$([ "$(uname -m)" == "x86_64" ] && echo "./7DaysToDieServer.x86_64" || echo "./7DaysToDieServer.x86")
 servercfgdefault="serverconfig.xml"
 servercfgdirdefault="${serverfiles}"
 servercfgfullpathdefault="${servercfgdirdefault}/${servercfgdefault}"


### PR DESCRIPTION
# Description

* Standardised 32/64 bit binarys are automatically selected for servers without there own script. 
* Removed manual selection for Hurtworld
* Changes to the website now correctly reflect if servers are 32 or 64 bit

Fixes #1436 

## Type of change

* [ ] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [X] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).
* [ ] This change requires a documentation update.

## Checklist

* [x] This code follows the style guidelines of this project.
* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [ ] I have provided Co-author details below.
* [x] I have performed a self-review of my own code.
* [ ] I have squashed commits.
* [ ] I have commented my code, particularly in hard to understand areas.
* [ ] I have made corresponding changes to the documentation if required.

## Provide Github Email

Fill out below info or tick box below:
```
Co-authored-by: John Doe <name@example.com>
```

- [ ] I do not wish to provide an email. I am aware this will hide me as the author of this commit.


All pull requests will now be squashed to create a tidy commit history and simplify changelog creation. You can provide either your own email or a GitHub-provided no-reply email.

When a PR is squashed the author becomes the person who squashed the PR. This removes you as the author of your own PR.
The only workaround for this is to add your details as a co-author. More info about co-authors can be found [here](https://help.github.com/en/articles/creating-a-commit-with-multiple-authors).
