### PR TITLE
fix(ts3server):  fix ability to update TS3 on older i686 arch.

### DIFF
--- a/lgsm/functions/update_ts3.sh
+++ b/lgsm/functions/update_ts3.sh
@@ -103,9 +103,9 @@ fn_update_ts3_localbuild(){
 
 fn_update_ts3_remotebuild(){
 	# Gets remote build info.
-	if [ "${arch}" == "x86_64" ]; then
+	if [ "${ts3arch}" == "x86_64" ]; then
 		remotebuild="$(${curlpath} -s "https://www.teamspeak.com/versions/server.json" | jq -r '.linux.x86_64.version')"
-	elif [ "${arch}" == "x86" ]; then
+	elif [ "${ts3arch}" == "x86" ]; then
 		remotebuild="$(${curlpath} -s "https://www.teamspeak.com/versions/server.json" | jq -r '.linux.x86.version')"
 	fi
 	if [ "${installer}" != "1" ]; then


### PR DESCRIPTION
# Description

Fixed two variables in script, so, now update on i686 arch is working fine.
Tested on my own server.

## Type of change

* [x] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).
* [ ] This change requires a documentation update.

## Checklist

* [x] This code follows the style guidelines of this project.
* [ ] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] I have provided Co-author details below.
* [x] I have performed a self-review of my own code.
* [ ] I have squashed commits.
* [ ] I have commented my code, particularly in hard to understand areas.
* [ ] I have made corresponding changes to the documentation if required.

## Provide Github Email

Fill out below info or tick box below:
```
Co-authored-by: Kirill Shamilin <kirill@shamilin.ru>
```

- [ ] I do not wish to provide an email. I am aware this will hide me as the author of this commit.


All pull requests will now be squashed to create a tidy commit history and simplify changelog creation. You can provide either your own email or a GitHub-provided no-reply email.

When a PR is squashed the author becomes the person who squashed the PR. This removes you as the author of your own PR.
The only workaround for this is to add your details as a co-author. More info about co-authors can be found [here](https://help.github.com/en/articles/creating-a-commit-with-multiple-authors).
