### PR TITLE
Revert "fix(ts3server):  fix ability to update TS3 on older i686 arch."

### DIFF
--- a/lgsm/functions/update_ts3.sh
+++ b/lgsm/functions/update_ts3.sh
@@ -103,9 +103,9 @@ fn_update_ts3_localbuild(){
 
 fn_update_ts3_remotebuild(){
 	# Gets remote build info.
-	if [ "${ts3arch}" == "x86_64" ]; then
+	if [ "${arch}" == "x86_64" ]; then
 		remotebuild="$(${curlpath} -s "https://www.teamspeak.com/versions/server.json" | jq -r '.linux.x86_64.version')"
-	elif [ "${ts3arch}" == "x86" ]; then
+	elif [ "${arch}" == "x86" ]; then
 		remotebuild="$(${curlpath} -s "https://www.teamspeak.com/versions/server.json" | jq -r '.linux.x86.version')"
 	fi
 	if [ "${installer}" != "1" ]; then


### PR DESCRIPTION
PR did not fix any issue and was causing tests to fail. Re-tested master version and working OK

Reverts GameServerManagers/LinuxGSM#2367
fixes #2373