### PR TITLE
update default gamemode='1' and address the issue #2031

### DIFF
--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -29,6 +29,8 @@ sourcetvport="27020"
 defaultmap="de_mirage"
 maxplayers="16"
 tickrate="64"
+svlan="0"
+svcheats="0"
 
 ## Required: Game Server Login Token
 # GSLT is required for running a public server.
@@ -43,7 +45,7 @@ wsstartmap=""
 
 ## Server Start Command | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
 fn_parms(){
-parms="-game csgo -usercon -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} +sv_setsteamaccount ${gslt} -tickrate ${tickrate} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers_override ${maxplayers} +mapgroup ${mapgroup} +game_type ${gametype} +game_mode ${gamemode} +host_workshop_collection ${wscollectionid} +workshop_start_map ${wsstartmap} -authkey ${wsapikey} -nobreakpad"
+parms="-game csgo -usercon -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} +sv_setsteamaccount ${gslt} -tickrate ${tickrate} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers_override ${maxplayers} +mapgroup ${mapgroup} +game_type ${gametype} +game_mode ${gamemode} +host_workshop_collection ${wscollectionid} +workshop_start_map ${wsstartmap} -authkey ${wsapikey} +sv_lan ${svlan} +sv_cheats ${svcheats} -nobreakpad"
 }
 
 #### LinuxGSM Settings ####

--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -20,7 +20,7 @@
 # Wingman				0			2
 # Danger Zone			6			0			mg_dz_blacksite (map: dz_blacksite), mg_dz_sirocco (map: dz_sirocco)
 gametype="0"
-gamemode="0"
+gamemode="1"
 mapgroup="mg_active"
 ip="0.0.0.0"
 port="27015"


### PR DESCRIPTION
`commit` [0db1e2f](https://github.com/GameServerManagers/LinuxGSM/pull/2442/commits/0db1e2f07062c91dd54d2eb25db08d06b7a51351) deals with updating the default `gamemode='1'` to start the server as a **competitive match** rather than a casual match.

**and**

`commit` [0971a64](https://github.com/GameServerManagers/LinuxGSM/pull/2442/commits/0971a642345ea08a09da707405fba42714b1881e) deals with #2031 and servers to solve the issue with adding `sv_lan 0` and `sv_cheats 0` explicitly under the default starting parameters argument list.