### PR TITLE
Battalion 1944: Updates to start up parameters 

### DIFF
--- a/lgsm/config-default/config-lgsm/bt1944server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bt1944server/_default.cfg
@@ -15,7 +15,7 @@ queryport="7780"
 
 ## Server Start Command | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
 fn_parms(){
-parms="/Game/Maps/Final_Maps/Derailed?Game=/Script/ShooterGame.BombGameMode?listen -log -broadcastip=\"${ip}\" -PORT=${port} -QueryPort=${queryport} -defgameini=\"${servercfgfullpath}\""
+parms="/Game/Maps/Final_Maps/Derailed?Game=/Script/ShooterGame.WartideGameMode?listen -log -broadcastip=\"${ip}\" -PORT=${port} -QueryPort=${queryport} -defgameini=\"${servercfgfullpath}\""
 }
 
 #### LinuxGSM Settings ####

--- a/lgsm/config-default/config-lgsm/bt1944server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bt1944server/_default.cfg
@@ -15,7 +15,7 @@ queryport="7780"
 
 ## Server Start Command | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
 fn_parms(){
-parms="/Game/Maps/Final_Maps/Derailed?Game=/Script/ShooterGame.WartideGameMode?listen -log -broadcastip=\"${ip}\" -PORT=${port} -QueryPort=${queryport} -defgameini=\"${servercfgfullpath}\""
+parms="/Game/Maps/Final_Maps/Derailed?Game=/Script/ShooterGame.WartideGameMode?listen -log -broadcastip=\"${extip}\" -PORT=${port} -QueryPort=${queryport} -defgameini=\"${servercfgfullpath}\""
 }
 
 #### LinuxGSM Settings ####


### PR DESCRIPTION
# Description

Updates to the server start command for Battalion 1994:

1. Change from IP to External IP (#2397) which can solve issues when LinuxGSM is run in a VM - Needs checking please, read my commit comment.
2. Update the reference of `BombGameMode` to `WartideGameMode` to match current server builds.

Fixes #2397

## Type of change

* [x] Bug fix (change which fixes an issue).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] I have provided a detailed enough description of this PR.

## Provide Github Email

Fill out below info or tick box below:
```
Co-authored-by: David Rayner <davidrayner500@gmail.com>
```

All pull requests will now be squashed to create a tidy commit history and simplify changelog creation. You can provide either your own email or a GitHub-provided no-reply email.

When a PR is squashed the author becomes the person who squashed the PR. This removes you as the author of your own PR.
The only workaround for this is to add your details as a co-author. More info about co-authors can be found [here](https://help.github.com/en/articles/creating-a-commit-with-multiple-authors).
