### PR TITLE
fix(btserver): Barotrauma has a new server binary location

### DIFF
--- a/lgsm/config-default/config-lgsm/btserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/btserver/_default.cfg
@@ -109,7 +109,7 @@ glibc="2.17"
 ## Server Specific Directories
 systemdir="${serverfiles}"
 executabledir="${systemdir}"
-executable="./Launch_DedicatedServer"
+executable="./DedicatedServer.exe"
 servercfg="serversettings.xml"
 servercfgdefault="serversettings.xml"
 servercfgdir="${systemdir}"

--- a/lgsm/functions/info_messages.sh
+++ b/lgsm/functions/info_messages.sh
@@ -1206,7 +1206,7 @@ fn_info_message_mordhau(){
 }
 
 fn_info_message_barotrauma(){
-	echo "netstat -atunp | grep /./DedicatedSer"
+	echo "netstat -atunp | grep /./Server.bin"
 	echo -e ""
 	{
 		echo -e "DESCRIPTION\tDIRECTION\tPORT\tPROTOCOL"


### PR DESCRIPTION
# Description

Fix server binary for Barotrauma 

Fixes #2453

## Type of change

* [x] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This code follows the style guidelines of this project.
* [x] I have provided Co-author details below.
* [x] I have performed a self-review of my own code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [x] I have checked If documentation needs updating.

## Provide Github Email

Fill out below info or tick box below:
```
Co-authored-by: John Doe <chris.h3o66@gmail.com>
```

- [ ] I do not wish to provide an email. I am aware this will hide me as the author of this commit.

All pull requests will now be squashed to create a tidy commit history and simplify changelog creation. You can provide either your own email or a GitHub-provided no-reply email.

When a PR is squashed the author becomes the person who squashed the PR. This removes you as the author of your own PR.
The only workaround for this is to add your details as a co-author. More info about co-authors can be found [here](https://help.github.com/en/articles/creating-a-commit-with-multiple-authors).

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
