### PR TITLE
fix(rustserver): new oxide download link for linux build 06.09.2019

### DIFF
--- a/lgsm/functions/mods_list.sh
+++ b/lgsm/functions/mods_list.sh
@@ -37,7 +37,8 @@ get5latestfile="$(echo "${get5scrapepath}" | xargs -n 1 -I @ sh -c "echo "basena
 get5downloadurl="https://ci.splewis.net/job/get5/lastSuccessfulBuild/artifact/${get5scrapepath}"
 get5url="${get5downloadurl}"
 # Oxide
-oxiderustlatestlink="$(curl -sL https://api.github.com/repos/theumod/umod.rust/releases/latest | grep browser_download_url | cut -d '"' -f 4)"
+#oxiderustlatestlink="$(curl -sL https://api.github.com/repos/theumod/umod.rust/releases/latest | grep browser_download_url | cut -d '"' -f 4)"
+oxiderustlatestlink="https://umod.org/games/rust/download/develop" # fix for linux build 06.09.2019
 oxidehurtworldlatestlink="$(curl -sL https://api.github.com/repos/OxideMod/Oxide.Hurtworld/releases/latest | grep browser_download_url | cut -d '"' -f 4 | grep "Oxide.Hurtworld.zip")"
 oxidesdtdlatestlink="$(curl -sL https://api.github.com/repos/OxideMod/Oxide.SevenDaysToDie/releases/latest | grep browser_download_url | cut -d '"' -f 4)"
 

--- a/lgsm/functions/mods_list.sh
+++ b/lgsm/functions/mods_list.sh
@@ -93,7 +93,7 @@ mod_info_darkrpmodification=( MOD "darkrpmodification" "DarkRP Modification" "ht
 
 
 # Oxidemod
-mod_info_rustoxide=( MOD "rustoxide" "Oxide for Rust" "${oxiderustlatestlink}" "Oxide.Rust.zip" "0" "LowercaseOff" "${systemdir}" "OVERWRITE" "ENGINES" "Rust;" "NOTGAMES" "http://oxidemod.org/downloads/oxide-for-rust.1659/" "Allows for the use of plugins" )
+mod_info_rustoxide=( MOD "rustoxide" "Oxide for Rust" "${oxiderustlatestlink}" "Oxide.Rust-linux.zip" "0" "LowercaseOff" "${systemdir}" "OVERWRITE" "ENGINES" "Rust;" "NOTGAMES" "http://oxidemod.org/downloads/oxide-for-rust.1659/" "Allows for the use of plugins" )
 mod_info_hwoxide=( MOD "hwoxide" "Oxide for Hurtworld" "${oxidehurtworldlatestlink}" "Oxide.Hurtworld.zip" "0" "LowercaseOff" "${systemdir}" "OVERWRITE" "ENGINES" "Hurtworld;" "NOTGAMES" "http://oxidemod.org/downloads/oxide-for-hurtworld.1332/" "Allows for the use of plugins" )
 mod_info_sdtdoxide=( MOD "sdtdoxide" "Oxide for 7 Days To Die" "${oxidesdtdlatestlink}" "Oxide.SevenDaysToDie.zip" "0" "LowercaseOff" "${systemdir}" "OVERWRITE" "ENGINES" "7 Days To Die;" "NOTGAMES" "http://oxidemod.org/downloads/oxide-for-7-days-to-die.813/" "Allows for the use of plugins" )
 

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -20,7 +20,7 @@ if [ -f ".dev-debug" ]; then
 	set -x
 fi
 
-version="v19.10.0"
+version="v19.10.1"
 shortname="core"
 gameservername="core"
 rootdir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"


### PR DESCRIPTION
# Description

Fix for oxide/umod download link for linux build.

Fixes #2498

## Type of change

* [x] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [ ] This code follows the style guidelines of this project.
* [ ] I have performed a self-review of my own code.
* [ ] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
