### PR TITLE
pass a name for the backup archive #2487

### DIFF
--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -37,8 +37,12 @@ fn_backup_check_lockfile(){
 
 # Initialisation.
 fn_backup_init(){
-	# Backup file name with servicename and current date.
-	backupname="${servicename}-$(date '+%Y-%m-%d-%H%M%S')"
+	# if the user didn't provide a name for the archive, create a name
+	# using the servicename and the date
+	if [ -z $backupname ]; then
+		# Backup file name with servicename and current date.
+		backupname="${servicename}-$(date '+%Y-%m-%d-%H%M%S')"
+	fi
 
 	info_distro.sh
 	fn_print_dots "Backup starting"

--- a/lgsm/functions/core_getopt.sh
+++ b/lgsm/functions/core_getopt.sh
@@ -186,7 +186,11 @@ for i in "${optcommands[@]}"; do
 			for ((currcmdindex=1; currcmdindex <= ${currcmdamount}; currcmdindex++)); do
 				if [ "$(echo "${currentopt[index]}" | awk -F ';' -v x=${currcmdindex} '{ print $x }')" == "${getopt}" ]; then
 					# Run command.
-					eval "${currentopt[index+1]}"
+					if [ "${currentopt[index+1]}" == "backup" ]||[ "${currentopt[index+1]}" == "b" ]; then
+						eval "${currentopt[index+1]} $backupname"
+					else
+						eval "${currentopt[index+1]}"
+					fi
 					core_exit.sh
 					break
 				fi

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -374,6 +374,10 @@ else
 	# Prevents running of core_exit.sh for Travis-CI.
 	if [ "${travistest}" != "1" ]; then
 		getopt=$1
+		if [ "$getopt" == "backup" ]||[ "$getopt" == "b" ]; then
+			# user can provide a name for the backup archive
+			backupname=$2
+		fi
 		core_getopt.sh
 	fi
 fi


### PR DESCRIPTION
# Description

Add the ability to pass a name for the backup archive. Currently the name of the backup archive is generated using this schema: `${servicename}-${date}`.


Fixes #2487 

## Type of change

* [ ] Bug fix (change which fixes an issue).
* [x] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs


