### PR TITLE
fix(utserver): remove SteamCMD auth requirement 32-bit workaround

### DIFF
--- a/lgsm/config-default/config-lgsm/untserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/untserver/_default.cfg
@@ -14,10 +14,6 @@ port="27015"
 maxplayers="20"
 defaultmap="pei"
 
-## SteamCMD Login | https://github.com/GameServerManagers/LinuxGSM/wiki/SteamCMD#steamcmd-login
-steamuser="username"
-steampass='password'
-
 ## Server Start Command | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
 
 # Parameters are changed in game.ini and engine.ini (Location: ${systemdir}/Saved/Config/LinuxServer)

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -104,9 +104,6 @@ fn_install_server_files_steamcmd(){
 				if [ "${appid}" == "90" ]; then
 					${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${serverfiles}" +app_set_config 90 mod "${appidmod}" +app_update "${appid}" ${branch} +quit
 					local exitcode=$?
-				elif [ "${shortname}" == "unt" ]; then
-					${unbuffer} ./steamcmd.sh +@sSteamCmdForcePlatformBitness 32 +login "${steamuser}" "${steampass}" +force_install_dir "${serverfiles}" +app_update "${appid}" ${branch} validate +quit
-					local exitcode=$?
 				else
 					${unbuffer} ./steamcmd.sh +login "${steamuser}" "${steampass}" +force_install_dir "${serverfiles}" +app_update "${appid}" ${branch} +quit
 					local exitcode=$?

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -20,7 +20,7 @@ if [ -f ".dev-debug" ]; then
 	set -x
 fi
 
-version="v19.9.0"
+version="v19.10.0"
 shortname="core"
 gameservername="core"
 rootdir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"


### PR DESCRIPTION
# Description

remove steam auth and remove the 32 bit install fix as it is not needed anymore.

Fixes #2411 

## Type of change

* [x] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
