### PR TITLE
feat(stop): stop type can now be set in _default.cfg

### DIFF
--- a/lgsm/config-default/config-lgsm/ahlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ahlserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Action half-life"

--- a/lgsm/config-default/config-lgsm/ahlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ahlserver/_default.cfg
@@ -112,10 +112,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/arkserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arkserver/_default.cfg
@@ -106,6 +106,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="ARK: Survival Evolved"

--- a/lgsm/config-default/config-lgsm/arkserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arkserver/_default.cfg
@@ -113,9 +113,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/arma3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arma3server/_default.cfg
@@ -127,9 +127,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/arma3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arma3server/_default.cfg
@@ -120,6 +120,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="ARMA 3"

--- a/lgsm/config-default/config-lgsm/bb2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bb2server/_default.cfg
@@ -117,9 +117,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/bb2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bb2server/_default.cfg
@@ -110,6 +110,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="BrainBread 2"

--- a/lgsm/config-default/config-lgsm/bbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bbserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="BrainBread"

--- a/lgsm/config-default/config-lgsm/bbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bbserver/_default.cfg
@@ -112,10 +112,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/bdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bdserver/_default.cfg
@@ -104,6 +104,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Base Defense"

--- a/lgsm/config-default/config-lgsm/bdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bdserver/_default.cfg
@@ -111,10 +111,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/bf1942server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bf1942server/_default.cfg
@@ -96,9 +96,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/bf1942server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bf1942server/_default.cfg
@@ -89,6 +89,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Battlefield: 1942"

--- a/lgsm/config-default/config-lgsm/bmdmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bmdmserver/_default.cfg
@@ -117,9 +117,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/bmdmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bmdmserver/_default.cfg
@@ -110,6 +110,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Black Mesa: Deathmatch"

--- a/lgsm/config-default/config-lgsm/boserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/boserver/_default.cfg
@@ -110,9 +110,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/boserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/boserver/_default.cfg
@@ -103,6 +103,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Ballistic Overkill"

--- a/lgsm/config-default/config-lgsm/bsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bsserver/_default.cfg
@@ -121,9 +121,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/bsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bsserver/_default.cfg
@@ -114,6 +114,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Blade Symphony"

--- a/lgsm/config-default/config-lgsm/bt1944server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bt1944server/_default.cfg
@@ -102,6 +102,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Battalion 1944"

--- a/lgsm/config-default/config-lgsm/bt1944server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bt1944server/_default.cfg
@@ -109,9 +109,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/btserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/btserver/_default.cfg
@@ -97,6 +97,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="9"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Barotrauma"

--- a/lgsm/config-default/config-lgsm/btserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/btserver/_default.cfg
@@ -104,10 +104,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="9"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="7"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/ccserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ccserver/_default.cfg
@@ -112,9 +112,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/ccserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ccserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Codename CURE"

--- a/lgsm/config-default/config-lgsm/cod2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cod2server/_default.cfg
@@ -92,6 +92,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Call of Duty 2"

--- a/lgsm/config-default/config-lgsm/cod2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cod2server/_default.cfg
@@ -99,9 +99,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/cod4server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cod4server/_default.cfg
@@ -92,6 +92,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Call of Duty 4"

--- a/lgsm/config-default/config-lgsm/cod4server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cod4server/_default.cfg
@@ -99,9 +99,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/codserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/codserver/_default.cfg
@@ -92,6 +92,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Call of Duty"

--- a/lgsm/config-default/config-lgsm/codserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/codserver/_default.cfg
@@ -99,9 +99,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/coduoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/coduoserver/_default.cfg
@@ -92,6 +92,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Call of Duty: United Offensive"

--- a/lgsm/config-default/config-lgsm/coduoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/coduoserver/_default.cfg
@@ -99,9 +99,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/codwawserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/codwawserver/_default.cfg
@@ -92,6 +92,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Call of Duty: World at War"

--- a/lgsm/config-default/config-lgsm/codwawserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/codwawserver/_default.cfg
@@ -99,9 +99,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/csczserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csczserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Counter-Strike: Condition Zero"

--- a/lgsm/config-default/config-lgsm/csczserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csczserver/_default.cfg
@@ -112,10 +112,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -137,9 +137,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -130,6 +130,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Counter-Strike: Global Offensive"

--- a/lgsm/config-default/config-lgsm/csserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Counter-Strike 1.6"

--- a/lgsm/config-default/config-lgsm/csserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csserver/_default.cfg
@@ -112,10 +112,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/cssserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cssserver/_default.cfg
@@ -117,9 +117,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/cssserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cssserver/_default.cfg
@@ -110,6 +110,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Counter-Strike: Source"

--- a/lgsm/config-default/config-lgsm/dabserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dabserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Double Action: Boogaloo"

--- a/lgsm/config-default/config-lgsm/dabserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dabserver/_default.cfg
@@ -112,9 +112,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/dmcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dmcserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Deathmatch Classic"

--- a/lgsm/config-default/config-lgsm/dmcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dmcserver/_default.cfg
@@ -112,10 +112,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/dodserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dodserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Day of Defeat"

--- a/lgsm/config-default/config-lgsm/dodserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dodserver/_default.cfg
@@ -112,10 +112,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/dodsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dodsserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Day of Defeat: Source"

--- a/lgsm/config-default/config-lgsm/dodsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dodsserver/_default.cfg
@@ -112,9 +112,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/doiserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/doiserver/_default.cfg
@@ -114,9 +114,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/doiserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/doiserver/_default.cfg
@@ -107,6 +107,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Day of Infamy"

--- a/lgsm/config-default/config-lgsm/dstserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dstserver/_default.cfg
@@ -115,9 +115,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/dstserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dstserver/_default.cfg
@@ -108,6 +108,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Don't Starve Together"

--- a/lgsm/config-default/config-lgsm/dysserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dysserver/_default.cfg
@@ -117,9 +117,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/dysserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dysserver/_default.cfg
@@ -110,6 +110,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Dystopia"

--- a/lgsm/config-default/config-lgsm/ecoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ecoserver/_default.cfg
@@ -93,6 +93,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Eco"

--- a/lgsm/config-default/config-lgsm/ecoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ecoserver/_default.cfg
@@ -100,9 +100,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/emserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/emserver/_default.cfg
@@ -117,9 +117,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/emserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/emserver/_default.cfg
@@ -110,6 +110,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Empires Mod"

--- a/lgsm/config-default/config-lgsm/etlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/etlserver/_default.cfg
@@ -93,9 +93,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/etlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/etlserver/_default.cfg
@@ -86,6 +86,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="ET: Legacy"

--- a/lgsm/config-default/config-lgsm/fctrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/fctrserver/_default.cfg
@@ -104,9 +104,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/fctrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/fctrserver/_default.cfg
@@ -97,6 +97,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Factorio"

--- a/lgsm/config-default/config-lgsm/fofserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/fofserver/_default.cfg
@@ -112,9 +112,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/fofserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/fofserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Fistful of Frags"

--- a/lgsm/config-default/config-lgsm/gesserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/gesserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="GoldenEye: Source"

--- a/lgsm/config-default/config-lgsm/gesserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/gesserver/_default.cfg
@@ -112,9 +112,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/gmodserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/gmodserver/_default.cfg
@@ -121,6 +121,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Garry's Mod"

--- a/lgsm/config-default/config-lgsm/gmodserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/gmodserver/_default.cfg
@@ -128,9 +128,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Half Life 2: Deathmatch"

--- a/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
@@ -112,9 +112,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/hldmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hldmserver/_default.cfg
@@ -104,6 +104,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode=""
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Half Life: Deathmatch"

--- a/lgsm/config-default/config-lgsm/hldmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hldmserver/_default.cfg
@@ -111,10 +111,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode=""
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/hldmsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hldmsserver/_default.cfg
@@ -112,9 +112,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/hldmsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hldmsserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Half-Life Deathmatch: Source"

--- a/lgsm/config-default/config-lgsm/hwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hwserver/_default.cfg
@@ -116,6 +116,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Hurtworld"

--- a/lgsm/config-default/config-lgsm/hwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hwserver/_default.cfg
@@ -123,9 +123,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/insserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/insserver/_default.cfg
@@ -112,6 +112,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Insurgency"

--- a/lgsm/config-default/config-lgsm/insserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/insserver/_default.cfg
@@ -119,9 +119,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/inssserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/inssserver/_default.cfg
@@ -113,6 +113,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Insurgency: Sandstorm"

--- a/lgsm/config-default/config-lgsm/inssserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/inssserver/_default.cfg
@@ -120,9 +120,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/iosserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/iosserver/_default.cfg
@@ -112,9 +112,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/iosserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/iosserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="IOSoccer"

--- a/lgsm/config-default/config-lgsm/jc2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jc2server/_default.cfg
@@ -97,6 +97,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Just Cause 2"

--- a/lgsm/config-default/config-lgsm/jc2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jc2server/_default.cfg
@@ -104,9 +104,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/jc3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jc3server/_default.cfg
@@ -97,6 +97,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Just Cause 3"

--- a/lgsm/config-default/config-lgsm/jc3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jc3server/_default.cfg
@@ -104,9 +104,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/kf2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/kf2server/_default.cfg
@@ -110,9 +110,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/kf2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/kf2server/_default.cfg
@@ -103,6 +103,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Killing Floor 2"

--- a/lgsm/config-default/config-lgsm/kfserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/kfserver/_default.cfg
@@ -116,9 +116,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/kfserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/kfserver/_default.cfg
@@ -109,6 +109,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Killing Floor"

--- a/lgsm/config-default/config-lgsm/l4d2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/l4d2server/_default.cfg
@@ -111,9 +111,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/l4d2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/l4d2server/_default.cfg
@@ -104,6 +104,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Left 4 Dead 2"

--- a/lgsm/config-default/config-lgsm/l4dserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/l4dserver/_default.cfg
@@ -104,6 +104,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Left 4 Dead"

--- a/lgsm/config-default/config-lgsm/l4dserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/l4dserver/_default.cfg
@@ -111,9 +111,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/mcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mcserver/_default.cfg
@@ -91,6 +91,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="5"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Minecraft"

--- a/lgsm/config-default/config-lgsm/mcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mcserver/_default.cfg
@@ -98,9 +98,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="5"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/mhserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mhserver/_default.cfg
@@ -109,9 +109,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/mhserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mhserver/_default.cfg
@@ -102,6 +102,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="MORDHAU"

--- a/lgsm/config-default/config-lgsm/mtaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mtaserver/_default.cfg
@@ -94,9 +94,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="4"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/mtaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mtaserver/_default.cfg
@@ -87,6 +87,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="4"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Multi Theft Auto"

--- a/lgsm/config-default/config-lgsm/mumbleserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mumbleserver/_default.cfg
@@ -90,6 +90,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Mumble"

--- a/lgsm/config-default/config-lgsm/mumbleserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mumbleserver/_default.cfg
@@ -97,9 +97,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/ndserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ndserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Nuclear Dawn"

--- a/lgsm/config-default/config-lgsm/ndserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ndserver/_default.cfg
@@ -112,9 +112,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
@@ -117,9 +117,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
@@ -110,6 +110,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="No More Room in Hell"

--- a/lgsm/config-default/config-lgsm/ns2cserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ns2cserver/_default.cfg
@@ -119,9 +119,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="6"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/ns2cserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ns2cserver/_default.cfg
@@ -112,6 +112,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="6"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="NS2: Combat"

--- a/lgsm/config-default/config-lgsm/ns2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ns2server/_default.cfg
@@ -116,6 +116,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="6"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Natural Selection 2"

--- a/lgsm/config-default/config-lgsm/ns2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ns2server/_default.cfg
@@ -123,9 +123,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="6"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/nsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/nsserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Natural Selection"

--- a/lgsm/config-default/config-lgsm/nsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/nsserver/_default.cfg
@@ -112,10 +112,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/opforserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/opforserver/_default.cfg
@@ -112,10 +112,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/opforserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/opforserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Half-Life: Opposing Force"

--- a/lgsm/config-default/config-lgsm/pcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pcserver/_default.cfg
@@ -97,6 +97,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Project Cars"

--- a/lgsm/config-default/config-lgsm/pcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pcserver/_default.cfg
@@ -104,9 +104,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/pstbsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pstbsserver/_default.cfg
@@ -115,9 +115,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/pstbsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pstbsserver/_default.cfg
@@ -108,6 +108,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="pstbsserver"

--- a/lgsm/config-default/config-lgsm/pvkiiserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pvkiiserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Pirates, Vikings, and Knights II"

--- a/lgsm/config-default/config-lgsm/pvkiiserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pvkiiserver/_default.cfg
@@ -112,9 +112,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/pzserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pzserver/_default.cfg
@@ -100,6 +100,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Project Zomboid"

--- a/lgsm/config-default/config-lgsm/pzserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pzserver/_default.cfg
@@ -107,9 +107,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/q2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/q2server/_default.cfg
@@ -91,6 +91,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Quake 2"

--- a/lgsm/config-default/config-lgsm/q2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/q2server/_default.cfg
@@ -98,9 +98,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/q3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/q3server/_default.cfg
@@ -91,6 +91,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Quake 3: Arena"

--- a/lgsm/config-default/config-lgsm/q3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/q3server/_default.cfg
@@ -98,9 +98,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/qlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qlserver/_default.cfg
@@ -99,6 +99,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Quake Live"

--- a/lgsm/config-default/config-lgsm/qlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qlserver/_default.cfg
@@ -106,9 +106,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/qwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qwserver/_default.cfg
@@ -97,9 +97,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/qwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qwserver/_default.cfg
@@ -90,6 +90,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="QuakeWorld"

--- a/lgsm/config-default/config-lgsm/ricochetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ricochetserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Ricochet"

--- a/lgsm/config-default/config-lgsm/ricochetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ricochetserver/_default.cfg
@@ -112,10 +112,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/roserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/roserver/_default.cfg
@@ -112,9 +112,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/roserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/roserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Red Orchestra: Ostfront 41-45"

--- a/lgsm/config-default/config-lgsm/rtcwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rtcwserver/_default.cfg
@@ -91,6 +91,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Return to Castle Wolfenstein"

--- a/lgsm/config-default/config-lgsm/rtcwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rtcwserver/_default.cfg
@@ -98,9 +98,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/rustserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rustserver/_default.cfg
@@ -136,9 +136,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/rustserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rustserver/_default.cfg
@@ -129,6 +129,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Rust"

--- a/lgsm/config-default/config-lgsm/rwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rwserver/_default.cfg
@@ -100,6 +100,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Rising World"

--- a/lgsm/config-default/config-lgsm/rwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rwserver/_default.cfg
@@ -107,9 +107,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/sampserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sampserver/_default.cfg
@@ -90,6 +90,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode=""
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="San Andreas Multiplayer"

--- a/lgsm/config-default/config-lgsm/sampserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sampserver/_default.cfg
@@ -97,10 +97,11 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode=""
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="2"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/sbotsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sbotsserver/_default.cfg
@@ -109,9 +109,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/sbotsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sbotsserver/_default.cfg
@@ -102,6 +102,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="StickyBots"

--- a/lgsm/config-default/config-lgsm/sbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sbserver/_default.cfg
@@ -110,9 +110,10 @@ steammaster="flase"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/sbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sbserver/_default.cfg
@@ -103,6 +103,18 @@ appid="211820"
 branch=""
 steammaster="flase"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Starbound"

--- a/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
@@ -100,6 +100,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="7 Days To Die"

--- a/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
@@ -107,10 +107,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="2"
+# 9: Gold Source
+# teamspeak 3
+stopmode="8"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/sfcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sfcserver/_default.cfg
@@ -112,9 +112,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/sfcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sfcserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="SourceForts Classic"

--- a/lgsm/config-default/config-lgsm/sof2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sof2server/_default.cfg
@@ -91,6 +91,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Soldier Of Fortune 2: Gold Edition"

--- a/lgsm/config-default/config-lgsm/sof2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sof2server/_default.cfg
@@ -98,9 +98,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/solserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/solserver/_default.cfg
@@ -99,9 +99,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/solserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/solserver/_default.cfg
@@ -92,6 +92,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Soldat"

--- a/lgsm/config-default/config-lgsm/squadserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/squadserver/_default.cfg
@@ -102,6 +102,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Squad"

--- a/lgsm/config-default/config-lgsm/squadserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/squadserver/_default.cfg
@@ -109,9 +109,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/ss3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ss3server/_default.cfg
@@ -101,6 +101,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Serious Sam 3: BFE"

--- a/lgsm/config-default/config-lgsm/ss3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ss3server/_default.cfg
@@ -108,9 +108,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/stserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/stserver/_default.cfg
@@ -107,6 +107,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Stationeers"

--- a/lgsm/config-default/config-lgsm/stserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/stserver/_default.cfg
@@ -114,9 +114,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/svenserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/svenserver/_default.cfg
@@ -111,10 +111,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/svenserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/svenserver/_default.cfg
@@ -104,6 +104,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Sven Co-op"

--- a/lgsm/config-default/config-lgsm/terrariaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/terrariaserver/_default.cfg
@@ -104,6 +104,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="9"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Terraria"

--- a/lgsm/config-default/config-lgsm/terrariaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/terrariaserver/_default.cfg
@@ -111,10 +111,11 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="9"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="7"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/tf2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tf2server/_default.cfg
@@ -117,9 +117,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/tf2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tf2server/_default.cfg
@@ -110,6 +110,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Team Fortress 2"

--- a/lgsm/config-default/config-lgsm/tfcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tfcserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Team Fortress Classic"

--- a/lgsm/config-default/config-lgsm/tfcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tfcserver/_default.cfg
@@ -112,10 +112,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/ts3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ts3server/_default.cfg
@@ -85,6 +85,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode=""
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="TeamSpeak 3"

--- a/lgsm/config-default/config-lgsm/ts3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ts3server/_default.cfg
@@ -92,9 +92,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode=""
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/tsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tsserver/_default.cfg
@@ -112,10 +112,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/tsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tsserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="The Specialists"

--- a/lgsm/config-default/config-lgsm/tuserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tuserver/_default.cfg
@@ -107,6 +107,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Tower Unite"

--- a/lgsm/config-default/config-lgsm/tuserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tuserver/_default.cfg
@@ -114,9 +114,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/twserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/twserver/_default.cfg
@@ -111,9 +111,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/twserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/twserver/_default.cfg
@@ -104,6 +104,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Teeworlds"

--- a/lgsm/config-default/config-lgsm/untserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/untserver/_default.cfg
@@ -115,9 +115,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/untserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/untserver/_default.cfg
@@ -108,6 +108,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Unturned"

--- a/lgsm/config-default/config-lgsm/ut2k4server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut2k4server/_default.cfg
@@ -90,6 +90,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Unreal Tournament 2004"

--- a/lgsm/config-default/config-lgsm/ut2k4server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut2k4server/_default.cfg
@@ -97,9 +97,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/ut3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut3server/_default.cfg
@@ -108,9 +108,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/ut3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut3server/_default.cfg
@@ -101,6 +101,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Unreal Tournament 3"

--- a/lgsm/config-default/config-lgsm/ut99server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut99server/_default.cfg
@@ -90,6 +90,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Unreal Tournament 99"

--- a/lgsm/config-default/config-lgsm/ut99server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut99server/_default.cfg
@@ -97,9 +97,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/utserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/utserver/_default.cfg
@@ -101,9 +101,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/utserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/utserver/_default.cfg
@@ -94,6 +94,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Unreal Tournament"

--- a/lgsm/config-default/config-lgsm/vsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vsserver/_default.cfg
@@ -112,10 +112,11 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
-stopmode="7"
+# 9: Gold Source
+# 10: Teamspeak 3
+stopmode="9"
 
 ## LinuxGSM Server Details
 # Do not edit

--- a/lgsm/config-default/config-lgsm/vsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vsserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="7"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Vampire Slayer"

--- a/lgsm/config-default/config-lgsm/wetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wetserver/_default.cfg
@@ -86,6 +86,18 @@ ansi="on"
 # Message Display Time
 sleeptime="0.5"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Wolfenstein: Enemy Territory"

--- a/lgsm/config-default/config-lgsm/wetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wetserver/_default.cfg
@@ -93,9 +93,10 @@ sleeptime="0.5"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/wurmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wurmserver/_default.cfg
@@ -96,6 +96,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="false"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="2"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Wurm Unlimited"

--- a/lgsm/config-default/config-lgsm/wurmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wurmserver/_default.cfg
@@ -103,9 +103,10 @@ steammaster="false"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="2"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/zmrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/zmrserver/_default.cfg
@@ -112,9 +112,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/zmrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/zmrserver/_default.cfg
@@ -105,6 +105,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Zombie Master: Reborn"

--- a/lgsm/config-default/config-lgsm/zpsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/zpsserver/_default.cfg
@@ -117,9 +117,10 @@ steammaster="true"
 # 4: quit 120s
 # 5: stop
 # 6: q
-# 7: goldsource
+# 7: exit
 # 8: 7 Days to Die
-# 9: exit
+# 9: Gold Source
+# 10: Teamspeak 3
 stopmode="3"
 
 ## LinuxGSM Server Details

--- a/lgsm/config-default/config-lgsm/zpsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/zpsserver/_default.cfg
@@ -110,6 +110,18 @@ branch=""
 # Master Server | https://docs.linuxgsm.com/steamcmd/steam-master-server
 steammaster="true"
 
+# Stop Mode | https://docs.linuxgsm.com/steamcmd/stopmode
+# 1: tmux kill
+# 2: CTRL+c
+# 3: quit
+# 4: quit 120s
+# 5: stop
+# 6: q
+# 7: goldsource
+# 8: 7 Days to Die
+# 9: exit
+stopmode="3"
+
 ## LinuxGSM Server Details
 # Do not edit
 gamename="Zombie Panic! Source"

--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -195,11 +195,13 @@ fn_stop_graceful_select(){
 	elif [ "${stopmode}" == "6" ]; then
 		fn_stop_graceful_cmd "q" 30
 	elif [ "${stopmode}" == "7" ]; then
-		fn_stop_graceful_goldsource
+		fn_stop_graceful_cmd "exit" 30
 	elif [ "${stopmode}" == "8" ]; then
 		fn_stop_graceful_sdtd
 	elif [ "${stopmode}" == "9" ]; then
-	fn_stop_graceful_cmd "exit" 30
+		fn_stop_graceful_goldsource
+	elif [ "${stopmode}" == "10" ]; then
+		fn_stop_teamspeak3
 	fi
 }
 

--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -181,24 +181,18 @@ fn_stop_graceful_sdtd(){
 }
 
 fn_stop_graceful_select(){
-	if [ "${shortname}" == "sdtd" ]; then
-		fn_stop_graceful_sdtd
-	elif [ "${engine}" == "spark" ]; then
-		fn_stop_graceful_cmd "q" 30
-	elif [ "${shortname}" == "terraria" ]; then
-		fn_stop_graceful_cmd "exit" 30
-	elif [ "${shortname}" == "mc" ]; then
-		fn_stop_graceful_cmd "stop" 30
-	elif [ "${shortname}" == "mta" ]; then
-		# Long wait time required for mta
-		# as resources shutdown individually.
-		fn_stop_graceful_cmd "quit" 120
-	elif [ "${engine}" == "goldsource" ]; then
-		fn_stop_graceful_goldsource
-	elif [ "${engine}" == "unity3d" ]||[ "${engine}" == "unreal4" ]||[ "${engine}" == "unreal3" ]||[ "${engine}" == "unreal2" ]||[ "${engine}" == "unreal" ]||[ "${shortname}" == "fctr" ]||[ "${shortname}" == "mumble" ]||[ "${shortname}" == "wurm" ]||[ "${shortname}" == "jc2" ]||[ "${shortname}" == "jc3" ]||[ "${shortname}" == "sol" ]; then
+	if [ "${stopmode}" == "1" ]; then
+		fn_stop_tmux
+	elif [ "${stopmode}" == "2" ]; then
 		fn_stop_graceful_ctrlc
-	elif  [ "${engine}" == "source" ]||[ "${engine}" == "quake" ]||[ "${engine}" == "idtech2" ]||[ "${engine}" == "idtech3" ]||[ "${engine}" == "idtech3_ql" ]||[ "${shortname}" == "pz" ]||[ "${shortname}" == "rw" ]; then
+	elif [ "${stopmode}" == "3" ]; then
 		fn_stop_graceful_cmd "quit" 30
+	elif [ "${stopmode}" == "4" ]; then
+		fn_stop_graceful_cmd "quit" 120
+	elif [ "${stopmode}" == "5" ]; then
+		fn_stop_graceful_cmd "stop" 30
+	elif [ "${stopmode}" == "6" ]; then
+		fn_stop_graceful_cmd "q" 30
 	fi
 }
 
@@ -232,7 +226,7 @@ fn_stop_ark(){
 				break
 			fi
 		done
-		if [[ ${pidcheck} -eq ${maxpiditer} ]] ; then
+		if [ "${pidcheck}" -eq "${maxpiditer}" ] ; then
 			# The process doesn't want to close after 20 seconds.
 			# kill it hard.
 			fn_print_error "Terminating reluctant Ark process: ${pid}"

--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -198,6 +198,8 @@ fn_stop_graceful_select(){
 		fn_stop_graceful_goldsource
 	elif [ "${stopmode}" == "8" ]; then
 		fn_stop_graceful_sdtd
+	elif [ "${stopmode}" == "9" ]; then
+	fn_stop_graceful_cmd "exit" 30
 	fi
 }
 

--- a/lgsm/functions/info_config.sh
+++ b/lgsm/functions/info_config.sh
@@ -1320,7 +1320,7 @@ elif [ "${engine}" == "source" ]||[ "${engine}" == "goldsource" ]; then
 # Starbound
 elif [ "${shortname}" == "sb" ]; then
 	fn_info_config_starbound
-# TeamSpeak 3
+# 10: Teamspeak 3
 elif [ "${shortname}" == "ts3" ]; then
 	fn_info_config_teamspeak3
 # Mumble


### PR DESCRIPTION
# Description

Migrate Graceful stop info to _default.cfg allowing developers to choose the setting easily.

Fixes #2517

## Type of change

* [ ] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [X] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
