### PR TITLE
Centos python dep checking V2

### DIFF
--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -452,7 +452,7 @@ fn_deps_build_redhat(){
 	elif [ "${distroversion}" == "7" ]; then
 		array_deps_required=( epel-release curl wget util-linux python3 file gzip bzip2 unzip binutils bc jq )
 	elif [ "${distroversion}" == "8" ]; then
-		array_deps_required=( epel-release curl wget util-linux python3 file gzip bzip2 unzip binutils bc jq )
+		array_deps_required=( epel-release curl wget util-linux python36 file gzip bzip2 unzip binutils bc jq )
 	elif [ "${distroid}" == "fedora" ]; then
 			array_deps_required=( curl wget util-linux python3 file gzip bzip2 unzip binutils bc jq )
 	elif [[ "${distroname}" == *"Amazon Linux AMI"* ]]; then

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -448,7 +448,7 @@ fn_deps_build_redhat(){
 	# LinuxGSM requirements.
 	# CentOS
 	if [ "${distroversion}" == "6" ]; then
-		array_deps_required=( epel-release curl wget util-linux-ng python3 file gzip bzip2 unzip binutils bc jq )
+		array_deps_required=( epel-release curl wget util-linux-ng python file gzip bzip2 unzip binutils bc jq )
 	elif [ "${distroversion}" == "7" ]; then
 		array_deps_required=( epel-release curl wget util-linux python3 file gzip bzip2 unzip binutils bc jq )
 	elif [ "${distroversion}" == "8" ]; then


### PR DESCRIPTION
# Description
you cant just change python to python3 in dependency array, because python3 is a META package, not an actually existed package, there's only 2 python package in centos 8: python2 and python36, attempting check python3 results dependency missing

There's no python3 in centos 6 repo so it better leaving it to python2 as the only reason of leaving centos 6 in codebase it keeping it from break (if any still running) existed installations

Fixes #2525

## Type of change

* [x] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [ ] This code follows the style guidelines of this project.
* [ ] I have performed a self-review of my own code.
* [ ] I have checked that this code is commented where required.
* [ ] I have provided a detailed enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
