### PR TITLE
Add space after "Game:" during install

### DIFF
--- a/lgsm/functions/install_header.sh
+++ b/lgsm/functions/install_header.sh
@@ -14,7 +14,7 @@ fn_sleep_time
 echo -e "================================="
 echo -e "${lightyellow}Linux${default}GSM_"
 echo -e "by Daniel Gibbs"
-echo -e "${lightblue}Game:${default}${gamename}"
+echo -e "${lightblue}Game:${default} ${gamename}"
 echo -e "${lightblue}Website:${default} https://linuxgsm.com"
 echo -e "${lightblue}Contributors:${default} https://linuxgsm.com/contrib"
 echo -e "${lightblue}Donate:${default} https://linuxgsm.com/donate"


### PR DESCRIPTION
# Description

Before: `Game:Counter-Strike: Global Offensive`
After: `Game: Counter-Strike: Global Offensive`

![image](https://user-images.githubusercontent.com/1230402/68059596-4a00c280-fcfd-11e9-99e6-5a2b72ec77aa.png)

## Type of change

* [ ] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [x] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [x] I have checked If documentation needs updating.