### PR TITLE
fix(alert): fixed typo in config change alert

### DIFF
--- a/lgsm/functions/alert.sh
+++ b/lgsm/functions/alert.sh
@@ -76,7 +76,7 @@ fn_alert_config(){
 	alertemoji="🎮"
 	alertsound="1"
 	alerturl="not enabled"
-	alertbody="${servicename} has recieved a new _default.cfg. Check file for changes."
+	alertbody="${servicename} has received a new _default.cfg. Check file for changes."
 }
 
 if [ "${alert}" == "permissions" ]; then


### PR DESCRIPTION
Simple typo fix.
