### PR TITLE
Feature/2597 https to http

### DIFF
--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -10,61 +10,61 @@ local function_selfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 fn_install_server_files(){
     if [ "${shortname}" == "ahl" ]; then
-		remote_fileurl="https://files.linuxgsm.com/ActionHalfLife/action_halflife-1.0.tar.bz2"; local_filedir="${tmpdir}"; local_filename="action_halflife-1.0.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="31430e670692b2eeaa0d1217db4dcb73"
+		remote_fileurl="http://files.linuxgsm.com/ActionHalfLife/action_halflife-1.0.tar.bz2"; local_filedir="${tmpdir}"; local_filename="action_halflife-1.0.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="31430e670692b2eeaa0d1217db4dcb73"
 	elif [ "${shortname}" == "bf1942" ]; then
-		remote_fileurl="https://files.linuxgsm.com/BattleField1942/bf1942_lnxded-1.61-hacked-to-1.612.full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="bf1942_lnxded-1.61-hacked-to-1.612.full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="a86a5d3cd64ca59abcc9bb9f777c2e5d"
+		remote_fileurl="http://files.linuxgsm.com/BattleField1942/bf1942_lnxded-1.61-hacked-to-1.612.full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="bf1942_lnxded-1.61-hacked-to-1.612.full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="a86a5d3cd64ca59abcc9bb9f777c2e5d"
 	elif [ "${shortname}" == "bb" ]; then
-		remote_fileurl="https://files.linuxgsm.com/BrainBread/brainbread-v1.2-linuxserver.tar.bz2"; local_filedir="${tmpdir}"; local_filename="brainbread-v1.2-linuxserver.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="5c729a7e9eecfa81b71a6a1f7267f0fd"
+		remote_fileurl="http://files.linuxgsm.com/BrainBread/brainbread-v1.2-linuxserver.tar.bz2"; local_filedir="${tmpdir}"; local_filename="brainbread-v1.2-linuxserver.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="5c729a7e9eecfa81b71a6a1f7267f0fd"
 	elif [ "${shortname}" == "cod" ]; then
-		remote_fileurl="https://files.linuxgsm.com/CallOfDuty/cod-lnxded-1.5b-full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="cod-lnxded-1.5-large.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="19629895a4cf6fd8f6d1ee198b5304cd"
+		remote_fileurl="http://files.linuxgsm.com/CallOfDuty/cod-lnxded-1.5b-full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="cod-lnxded-1.5-large.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="19629895a4cf6fd8f6d1ee198b5304cd"
 	elif [ "${shortname}" == "coduo" ]; then
-		remote_fileurl="https://files.linuxgsm.com/CallOfDutyUnitedOffensive/coduo-lnxded-1.51b-full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="coduo-lnxded-1.51b-full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="f1804ef13036e2b4ab535db000b19e97"
+		remote_fileurl="http://files.linuxgsm.com/CallOfDutyUnitedOffensive/coduo-lnxded-1.51b-full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="coduo-lnxded-1.51b-full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="f1804ef13036e2b4ab535db000b19e97"
 	elif [ "${shortname}" == "cod2" ]; then
-		remote_fileurl="https://files.linuxgsm.com/CallOfDuty2/cod2-lnxded-1.3-full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="cod2-lnxded-1.3-full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="078128f83d06dc3d7699428dc2870214"
+		remote_fileurl="http://files.linuxgsm.com/CallOfDuty2/cod2-lnxded-1.3-full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="cod2-lnxded-1.3-full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="078128f83d06dc3d7699428dc2870214"
 	elif [ "${shortname}" == "cod4" ]; then
-		remote_fileurl="https://files.linuxgsm.com/CallOfDuty4/cod4x18_1772_dedrun.tar.bz2"; local_filedir="${tmpdir}"; local_filename="cod4x18_1772_dedrun.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="de29f29d79f9cc24574b838daa501e46"
+		remote_fileurl="http://files.linuxgsm.com/CallOfDuty4/cod4x18_1772_dedrun.tar.bz2"; local_filedir="${tmpdir}"; local_filename="cod4x18_1772_dedrun.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="de29f29d79f9cc24574b838daa501e46"
 	elif [ "${shortname}" == "codwaw" ]; then
-		remote_fileurl="https://files.linuxgsm.com/CallOfDutyWorldAtWar/codwaw-lnxded-1.7-full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="codwaw-lnxded-1.7-full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="0489697ff3bf678c109bfb377d1b7895"
+		remote_fileurl="http://files.linuxgsm.com/CallOfDutyWorldAtWar/codwaw-lnxded-1.7-full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="codwaw-lnxded-1.7-full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="0489697ff3bf678c109bfb377d1b7895"
 	elif [ "${shortname}" == "etl" ]; then
-		remote_fileurl="https://files.linuxgsm.com/WolfensteinEnemyTerritory/etlegacy-v2.75-i386-et-260b.tar.bz2"; local_filedir="${tmpdir}"; local_filename="etlegacy-v2.75-i386-et-260b.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="92d7d4c26e0a295daed78cef623eeabb"
+		remote_fileurl="http://files.linuxgsm.com/WolfensteinEnemyTerritory/etlegacy-v2.75-i386-et-260b.tar.bz2"; local_filedir="${tmpdir}"; local_filename="etlegacy-v2.75-i386-et-260b.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="92d7d4c26e0a295daed78cef623eeabb"
 	elif [ "${shortname}" == "ges" ]; then
-		remote_fileurl="https://files.linuxgsm.com/GoldenEyeSource/GoldenEye_Source_v5.0.6_full_server.tar.bz2"; local_filedir="${tmpdir}"; local_filename="GoldenEye_Source_v5.0.6_full_server.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="c45c16293096706e8b5e2cd64a6f2931"
+		remote_fileurl="http://files.linuxgsm.com/GoldenEyeSource/GoldenEye_Source_v5.0.6_full_server.tar.bz2"; local_filedir="${tmpdir}"; local_filename="GoldenEye_Source_v5.0.6_full_server.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="c45c16293096706e8b5e2cd64a6f2931"
 	elif [ "${shortname}" == "mohaa" ]; then
-		remote_fileurl="https://files.linuxgsm.com/MedalofHonorAlliedAssault/moh_revival_v1.12_RC3.5.1.tar.bz2"; local_filedir="${tmpdir}"; local_filename="moh_revival_v1.12_RC3.5.1.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="9d5924486a0cf5e46dd063216aad05c1"
+		remote_fileurl="http://files.linuxgsm.com/MedalofHonorAlliedAssault/moh_revival_v1.12_RC3.5.1.tar.bz2"; local_filedir="${tmpdir}"; local_filename="moh_revival_v1.12_RC3.5.1.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="9d5924486a0cf5e46dd063216aad05c1"
 	elif [ "${shortname}" == "ns" ]; then
-		remote_fileurl="https://files.linuxgsm.com/NaturalSelection/ns_dedicated_server_v32.tar.bz2"; local_filedir="${tmpdir}"; local_filename="ns_dedicated_server_v32.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="499cf63324b76925ada6baf5f2eacd67"
+		remote_fileurl="http://files.linuxgsm.com/NaturalSelection/ns_dedicated_server_v32.tar.bz2"; local_filedir="${tmpdir}"; local_filename="ns_dedicated_server_v32.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="499cf63324b76925ada6baf5f2eacd67"
 	elif [ "${shortname}" == "q2" ]; then
-		remote_fileurl="https://files.linuxgsm.com/Quake2/quake2-3.20-glibc-i386-full-linux2.0.tar.bz2"; local_filedir="${tmpdir}"; local_filename="quake2-3.20-glibc-i386-full-linux2.0.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="0b8c7e2d51f40b56b328c69e986e7c5f"
+		remote_fileurl="http://files.linuxgsm.com/Quake2/quake2-3.20-glibc-i386-full-linux2.0.tar.bz2"; local_filedir="${tmpdir}"; local_filename="quake2-3.20-glibc-i386-full-linux2.0.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="0b8c7e2d51f40b56b328c69e986e7c5f"
 	elif [ "${shortname}" == "q3" ]; then
-		remote_fileurl="https://files.linuxgsm.com/Quake3/quake3-1.32c-x86-full-linux.tar.bz2"; local_filedir="${tmpdir}"; local_filename="quake3-1.32c-x86-full-linux.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="fd7258d827474f67663dda297bff4306"
+		remote_fileurl="http://files.linuxgsm.com/Quake3/quake3-1.32c-x86-full-linux.tar.bz2"; local_filedir="${tmpdir}"; local_filename="quake3-1.32c-x86-full-linux.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="fd7258d827474f67663dda297bff4306"
 	elif [ "${shortname}" == "qw" ]; then
-		remote_fileurl="https://files.linuxgsm.com/QuakeWorld/nquake.server.linux.190506.full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="nquake.server.linux.190506.full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="74405ec030463c5e1175e776ab572d32"
+		remote_fileurl="http://files.linuxgsm.com/QuakeWorld/nquake.server.linux.190506.full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="nquake.server.linux.190506.full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="74405ec030463c5e1175e776ab572d32"
 	elif [ "${shortname}" == "rtcw" ]; then
-		remote_fileurl="https://files.linuxgsm.com/ReturnToCastleWolfenstein/iortcw-1.51c-x86_64-server-linux-20190507.tar.bz2"; local_filedir="${tmpdir}"; local_filename="iortcw-1.51c-x86_64-server-linux-20190507.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="6a3be9700372b228d1187422464e4212"
+		remote_fileurl="http://files.linuxgsm.com/ReturnToCastleWolfenstein/iortcw-1.51c-x86_64-server-linux-20190507.tar.bz2"; local_filedir="${tmpdir}"; local_filename="iortcw-1.51c-x86_64-server-linux-20190507.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="6a3be9700372b228d1187422464e4212"
 	elif [ "${shortname}" == "sfc" ]; then
-		remote_fileurl="https://files.linuxgsm.com/SourceFortsClassic/SFClassic-1.0-RC7-fix.tar.bz2"; local_filedir="${tmpdir}"; local_filename="SFClassic-1.0-RC7-fix.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="e0d4cfd298a8a356053f92b1fa7d1002"
+		remote_fileurl="http://files.linuxgsm.com/SourceFortsClassic/SFClassic-1.0-RC7-fix.tar.bz2"; local_filedir="${tmpdir}"; local_filename="SFClassic-1.0-RC7-fix.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="e0d4cfd298a8a356053f92b1fa7d1002"
 	elif [ "${shortname}" == "sof2" ]; then
-		remote_fileurl="https://files.linuxgsm.com/SoldierOfFortune2/sof2gold-1.03.tar.bz2"; local_filedir="${tmpdir}"; local_filename="sof2gold-1.03.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="871b1dc0dafeeace65b198119e8fa200"
+		remote_fileurl="http://files.linuxgsm.com/SoldierOfFortune2/sof2gold-1.03.tar.bz2"; local_filedir="${tmpdir}"; local_filename="sof2gold-1.03.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="871b1dc0dafeeace65b198119e8fa200"
 	elif [ "${shortname}" == "ts" ]; then
-		remote_fileurl="https://files.linuxgsm.com/TheSpecialists/ts-3-linux-final.tar.bz2"; local_filedir="${tmpdir}"; local_filename="ts-3-linux-final.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="38e8a8325339f85a7745117802f940b7"
+		remote_fileurl="http://files.linuxgsm.com/TheSpecialists/ts-3-linux-final.tar.bz2"; local_filedir="${tmpdir}"; local_filename="ts-3-linux-final.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="38e8a8325339f85a7745117802f940b7"
 	elif [ "${shortname}" == "ut2k4" ]; then
-		remote_fileurl="https://files.linuxgsm.com/UnrealTournament2004/ut2004-server-3369-2-ultimate-linux.tar.bz2"; local_filedir="${tmpdir}"; local_filename="ut2004-server-3369-2-ultimate-linux.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="67c5e2cd9c2a4b04f163962ee41eff54"
+		remote_fileurl="http://files.linuxgsm.com/UnrealTournament2004/ut2004-server-3369-2-ultimate-linux.tar.bz2"; local_filedir="${tmpdir}"; local_filename="ut2004-server-3369-2-ultimate-linux.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="67c5e2cd9c2a4b04f163962ee41eff54"
 	elif [ "${shortname}" == "ut99" ]; then
-		remote_fileurl="https://files.linuxgsm.com/UnrealTournament99/ut99-server-451-ultimate-linux.tar.bz2"; local_filedir="${tmpdir}"; local_filename="ut99-server-451-ultimate-linux.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="49cb24d0550ff6ddeaba6007045c6edd"
+		remote_fileurl="http://files.linuxgsm.com/UnrealTournament99/ut99-server-451-ultimate-linux.tar.bz2"; local_filedir="${tmpdir}"; local_filename="ut99-server-451-ultimate-linux.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="49cb24d0550ff6ddeaba6007045c6edd"
 	elif [ "${shortname}" == "ut" ]; then
 		remote_fileurl="https://s3.amazonaws.com/unrealtournament/UnrealTournament-Client-XAN-3395761-Linux.zip"; local_filedir="${tmpdir}"; local_filename="UnrealTournament-Server-XAN-3395761-Linux.zip";  chmodx="noexecute" run="norun"; force="noforce"; md5="f04ad5b96865b19613303331ff4075eb"
 	elif [ "${shortname}" == "ut3" ]; then
-		remote_fileurl="https://files.linuxgsm.com/UnrealTournament3/UT3-linux-server-2.1.tar.bz2"; local_filedir="${tmpdir}"; local_filename="UT3-linux-server-2.1.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="2527437b46f1b47f20228d27d72395a6"
+		remote_fileurl="http://files.linuxgsm.com/UnrealTournament3/UT3-linux-server-2.1.tar.bz2"; local_filedir="${tmpdir}"; local_filename="UT3-linux-server-2.1.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="2527437b46f1b47f20228d27d72395a6"
 	elif [ "${shortname}" == "vs" ]; then
-		remote_fileurl="https://files.linuxgsm.com/VampireSlayer/vs_l-6.0_full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="vs_l-6.0_full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="38a79e44b98578bbdc5b15818493a066"
+		remote_fileurl="http://files.linuxgsm.com/VampireSlayer/vs_l-6.0_full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="vs_l-6.0_full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="38a79e44b98578bbdc5b15818493a066"
 	elif [ "${shortname}" == "wet" ]; then
-		remote_fileurl="https://files.linuxgsm.com/WolfensteinEnemyTerritory/enemy-territory.260b.tar.bz2"; local_filedir="${tmpdir}"; local_filename="enemy-territory.260b.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="f833f514bfcdd46b42c111f83350c5a7"
+		remote_fileurl="http://files.linuxgsm.com/WolfensteinEnemyTerritory/enemy-territory.260b.tar.bz2"; local_filedir="${tmpdir}"; local_filename="enemy-territory.260b.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="f833f514bfcdd46b42c111f83350c5a7"
 	elif [ "${shortname}" == "samp" ]; then
 		remote_fileurl="https://files.sa-mp.com/samp037svr_R2-1.tar.gz"; local_filedir="${tmpdir}"; local_filename="samp037svr_R2-1.tar.gz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="93705e165550c97484678236749198a4"
 	elif [ "${shortname}" == "sol" ]; then
 		remote_fileurl="https://static.soldat.pl/downloads/soldatserver2.8.1_1.7.1.zip"; local_filedir="${tmpdir}"; local_filename="soldatserver2.8.1_1.7.1.zip"; chmodx="nochmodx" run="norun"; force="noforce"; md5="994409c28520425965dec5c71ccb55e1"
 	elif [ "${shortname}" == "zmr" ]; then
-		remote_fileurl="https://files.linuxgsm.com/ZombieMasterReborn/zombie_master_reborn_b5_2.tar.bz2"; local_filedir="${tmpdir}"; local_filename="zombie_master_reborn_b5_2.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="d52ef2db376f5d21e3a4ceca85ec8761"
+		remote_fileurl="http://files.linuxgsm.com/ZombieMasterReborn/zombie_master_reborn_b5_2.tar.bz2"; local_filedir="${tmpdir}"; local_filename="zombie_master_reborn_b5_2.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="d52ef2db376f5d21e3a4ceca85ec8761"
 	fi
 	fn_fetch_file "${remote_fileurl}" "${local_filedir}" "${local_filename}" "${chmodx}" "${run}" "${forcedl}" "${md5}"
 	fn_dl_extract "${local_filedir}" "${local_filename}" "${serverfiles}"


### PR DESCRIPTION
# Description

Game Servers that don't use SteamCMD will now use http instead of https. This is because older versions of curl on older distros are not keeping up with https related technologies and causing downloads to fail. As there is no sensitive data being transferred revering to http will ensure compatibility.

Fixes #2597 
## Type of change

* [x] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
