### PR TITLE
fix(eco): remove mono 6 as a dependency for eco (mono 5 still required)

### DIFF
--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -430,9 +430,6 @@ fn_deps_build_debian(){
 	# Unreal Tournament
 	elif [ "${shortname}" == "ut" ]; then
 		array_deps_required+=( unzip )
-	# Eco
-	elif [ "${shortname}" == "eco" ]; then
-		array_deps_required+=( mono-complete )
 	# Wurm: Unlimited
 	elif [ "${shortname}" == "wurm" ]; then
 		array_deps_required+=( xvfb )
@@ -546,9 +543,6 @@ fn_deps_build_redhat(){
 	# Unreal Tournament
 	elif [ "${shortname}" == "ut" ]; then
 		array_deps_required+=( unzip )
-	# Eco
-	elif [ "${shortname}" == "eco" ]; then
-		array_deps_required+=( mono-complete )
 	# Unturned
 	elif [ "${shortname}" == "unt" ]; then
 		array_deps_required+=( mono-complete )


### PR DESCRIPTION
# Description

Removed mono as a dependency as LinuxGSM installs mono 6 using official mono repo. 

eco does not work with mono 6 and only with mono 5

mono 5 is available on official distro repos.

eco will be removing the requirement for mono in release 0.9.0. So there is no point making significant code changes to facilitate this temporary issue.

simply following the dependency requirements on the website will allow eco to work.

Fixes #2549 

## Type of change

* [X] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
