### PR TITLE
fix(sdtdserver): restore serverconfig setting

### DIFF
--- a/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
@@ -148,6 +148,7 @@ executable=$([ "$(uname -m)" == "x86_64" ] && echo -e "./7DaysToDieServer.x86_64
 servercfgdefault="serverconfig.xml"
 servercfgfullpathdefault="${serverfiles}/${servercfgdefault}"
 servercfgdir="${serverfiles}"
+servercfg="${selfname}.xml"
 servercfgfullpath="${servercfgdir}/${servercfg}"
 
 ## Backup Directory

--- a/lgsm/functions/core_legacy.sh
+++ b/lgsm/functions/core_legacy.sh
@@ -41,6 +41,10 @@ if [ -z "${alertlog}" ]; then
 	alertlog="${emaillog}"
 fi
 
+if [ -z "${servicename}" ]; then
+	servicename="${selfname}"
+fi
+
 # Alternations to workshop variables.
 if [ -z "${wsapikey}" ]; then
 	if [ "${workshopauth}" ]; then


### PR DESCRIPTION
# Description

Fixes sdtd config issue after upgrade to the latest release of lgsm that no config is there in the standard anymore

## Type of change

* [x] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [ ] This pull request Subject follows the Conventional Commits standard.
* [ ] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have checked that this code is commented where required.
* [ ] I have provided a detailed enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
