### PR TITLE
fix(nmrihserver): added symbolic links to fix the crashes related to missing files

### DIFF
--- a/lgsm/functions/core_functions.sh
+++ b/lgsm/functions/core_functions.sh
@@ -683,6 +683,11 @@ functionfile="${FUNCNAME[0]}"
 fn_fetch_function
 }
 
+install_nmrih_symlinks.sh(){
+functionfile="${FUNCNAME[0]}"
+fn_fetch_function
+}
+
 # Calls code required for legacy servers
 core_legacy.sh
 

--- a/lgsm/functions/install_nmrih_symlinks.sh
+++ b/lgsm/functions/install_nmrih_symlinks.sh
@@ -4,7 +4,7 @@
 # Description: Create symlinks for renamed No More Room In Hell serverfiles 
 # Solution from Steam Community post: https://steamcommunity.com/app/224260/discussions/2/1732089092441769414/
 
-local bin = ~/serverfiles/bin/
+local bin=~/serverfiles/bin/
 ln -s $bin/vphysics_srv.so $bin/vphysics.so
 ln -s $bin/studiorender_srv.so $bin/studiorender.so
 ln -s $bin/soundemittersystem_srv.so $bin/soundemittersystem.so

--- a/lgsm/functions/install_nmrih_symlinks.sh
+++ b/lgsm/functions/install_nmrih_symlinks.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# LinuxGSM install_nmrih_symlinks.sh function
+# Author: Denperidge
+# Description: Create symlinks for renamed No More Room In Hell serverfiles 
+# Solution from Steam Community post: https://steamcommunity.com/app/224260/discussions/2/1732089092441769414/
+
+local bin = ~/serverfiles/bin/
+ln -s $bin/vphysics_srv.so $bin/vphysics.so
+ln -s $bin/studiorender_srv.so $bin/studiorender.so
+ln -s $bin/soundemittersystem_srv.so $bin/soundemittersystem.so
+ln -s $bin/shaderapiempty_srv.so $bin/shaderapiempty.so
+ln -s $bin/scenefilecache_srv.so $bin/scenefilecache.so
+ln -s $bin/replay_srv.so $bin/replay.so
+ln -s $bin/materialsystem_srv.so $bin/materialsystem.so 

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -162,6 +162,8 @@ elif [ "${shortname}" == "mta" ]; then
 elif [ "${shortname}" == "fctr" ]; then
 	update_factorio.sh
 	install_factorio_save.sh
+elif [ "${shortname}" == "nmrih"]; then
+	install_nmrih_symlinks.sh
 elif [ -z "${appid}" ]||[ "${shortname}" == "ahl" ]||[ "${shortname}" == "bd" ]||[ "${shortname}" == "bb" ]||[ "${shortname}" == "ges" ]||[ "${shortname}" == "ns" ]||[ "${shortname}" == "sfc" ]||[ "${shortname}" == "sol" ]||[ "${shortname}" == "ts" ]||[ "${shortname}" == "vs" ]||[ "${shortname}" == "zmr" ]; then
 	if [ "${shortname}" == "ut" ]; then
 		install_eula.sh

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -162,7 +162,7 @@ elif [ "${shortname}" == "mta" ]; then
 elif [ "${shortname}" == "fctr" ]; then
 	update_factorio.sh
 	install_factorio_save.sh
-elif [ "${shortname}" == "nmrih"]; then
+elif [ "${shortname}" == "nmrih" ]; then
 	install_nmrih_symlinks.sh
 elif [ -z "${appid}" ]||[ "${shortname}" == "ahl" ]||[ "${shortname}" == "bd" ]||[ "${shortname}" == "bb" ]||[ "${shortname}" == "ges" ]||[ "${shortname}" == "ns" ]||[ "${shortname}" == "sfc" ]||[ "${shortname}" == "sol" ]||[ "${shortname}" == "ts" ]||[ "${shortname}" == "vs" ]||[ "${shortname}" == "zmr" ]; then
 	if [ "${shortname}" == "ut" ]; then

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -20,7 +20,7 @@ if [ -f ".dev-debug" ]; then
 	set -x
 fi
 
-version="v19.12.4"
+version="v19.12.5"
 shortname="core"
 gameservername="core"
 rootdir=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")


### PR DESCRIPTION
# Description

While installing the No More Room In Hell server went smooth, every startup after the first one results in a crash. The logs revealed that certain files were missing: these files - according to Steam Community posts - were renamed around 2018. I added a .sh file (based from a [fix posted on the Steam Community forums](https://steamcommunity.com/app/224260/discussions/2/1732089092441769414/)) that only runs on the No More Room In Hell server installation, which automatically creates symbolic links towards the old filenames.

Fixes #2665

## Type of change

* [x] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [ ] This pull request uses the `develop` branch as its base.
* [ ] This pull request Subject follows the Conventional Commits standard.
* [ ] This code follows the style guidelines of this project.
* [ ] I have performed a self-review of my own code.
* [ ] I have checked that this code is commented where required.
* [ ] I have provided a detailed enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
