### PR TITLE
feat(install): convert libstdc++6:i386 to lib32stdc++6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
     - postfix
     - jq
     - lib32gcc1
-    - libstdc++6:i386
+    - lib32stdc++6
     - shellcheck
     - libcurl4-openssl-dev
     - libdw-dev

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -192,7 +192,7 @@ fn_deps_detector(){
 		fi
 		# Define required dependencies for SteamCMD.
 		if [ -n "${appid}" ]; then
-			if [ "${deptocheck}" ==  "glibc.i686" ]||[ "${deptocheck}" ==  "libstdc++64.i686" ]||[ "${deptocheck}" ==  "lib32gcc1" ]||[ "${deptocheck}" ==  "libstdc++6:i386" ]; then
+			if [ "${deptocheck}" ==  "glibc.i686" ]||[ "${deptocheck}" ==  "libstdc++64.i686" ]||[ "${deptocheck}" ==  "lib32gcc1" ]||[ "${deptocheck}" ==  "lib32stdc++6" ]; then
 				steamcmdfail=1
 			fi
 		fi
@@ -346,9 +346,9 @@ fn_deps_build_debian(){
 	# All servers except ts3, mumble, GTA and minecraft servers require libstdc++6 and lib32gcc1.
 	if [ "${shortname}" != "ts3" ]&&[ "${shortname}" != "mumble" ]&&[ "${shortname}" != "mc" ]&&[ "${engine}" != "renderware" ]; then
 		if [ "${arch}" == "x86_64" ]; then
-			array_deps_required+=( lib32gcc1 libstdc++6:i386 )
+			array_deps_required+=( lib32gcc1 lib32stdc++6 )
 		else
-			array_deps_required+=( libstdc++6:i386 )
+			array_deps_required+=( lib32stdc++6 )
 		fi
 	fi
 


### PR DESCRIPTION
# Description

libstdc++.so.6 can be installed using lib32stdc++6 removing the need to add the i386 arch

Fixes #1896

## Type of change

* [ ] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [x] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
