### PR TITLE
fix(ark): fix broken steamcmd link preventing mods from working

### DIFF
--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -272,9 +272,14 @@ fn_found_missing_deps(){
 				fi
 				if [ "${steamcmdfail}" ]; then
 					echo -e ""
-					fn_print_failure_nl "Missing dependencies required to run SteamCMD."
-					fn_script_log_fatal "Missing dependencies required to run SteamCMD."
-					core_exit.sh
+					if [ "${function_selfname}" == "command_install.sh" ]; then
+						fn_print_failure_nl "Missing dependencies required to run SteamCMD."
+						fn_script_log_fatal "Missing dependencies required to run SteamCMD."
+						core_exit.sh
+					else
+						fn_print_error_nl "Missing dependencies required to run SteamCMD."
+						fn_script_log_error "Missing dependencies required to run SteamCMD."
+					fi
 				fi
 			else
 				fn_print_complete_nl "Install dependencies completed."
@@ -293,9 +298,14 @@ fn_found_missing_deps(){
 			fi
 			if [ "${steamcmdfail}" ]; then
 				echo -e ""
-				fn_print_failure_nl "Missing dependencies required to run SteamCMD."
-				fn_script_log_fatal "Missing dependencies required to run SteamCMD."
-				core_exit.sh
+				if [ "${function_selfname}" == "command_install.sh" ]; then
+					fn_print_failure_nl "Missing dependencies required to run SteamCMD."
+					fn_script_log_fatal "Missing dependencies required to run SteamCMD."
+					core_exit.sh
+				else
+					fn_print_error_nl "Missing dependencies required to run SteamCMD."
+					fn_script_log_error "Missing dependencies required to run SteamCMD."
+				fi
 			fi
 			echo -e ""
 		fi

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -337,7 +337,7 @@ fn_deps_build_debian(){
 	array_deps_missing=()
 
 	# LinuxGSM requirements.
-	array_deps_required=( curl wget ca-certificates file bsdmainutils util-linux python3 tar bzip2 gzip unzip binutils bc jq tmux )
+	array_deps_required=( curl wget ca-certificates file bsdmainutils util-linux python3 tar bzip2 gzip unzip binutils bc jq tmux netcat )
 
 	# All servers except ts3, mumble, GTA and minecraft servers require libstdc++6 and lib32gcc1.
 	if [ "${shortname}" != "ts3" ]&&[ "${shortname}" != "mumble" ]&&[ "${shortname}" != "mc" ]&&[ "${engine}" != "renderware" ]; then
@@ -455,15 +455,15 @@ fn_deps_build_redhat(){
 	# LinuxGSM requirements.
 	# CentOS
   if [ "${distroversion}" == "7" ]; then
-		array_deps_required=( epel-release curl wget util-linux python3 file tar gzip bzip2 unzip binutils bc jq tmux )
+		array_deps_required=( epel-release curl wget util-linux python3 file tar gzip bzip2 unzip binutils bc jq tmux nmap-ncat )
 	elif [ "${distroversion}" == "8" ]; then
-		array_deps_required=( epel-release curl wget util-linux python36 file tar gzip bzip2 unzip binutils bc jq tmux )
+		array_deps_required=( epel-release curl wget util-linux python36 file tar gzip bzip2 unzip binutils bc jq tmux nmap-ncat )
 	elif [ "${distroid}" == "fedora" ]; then
-			array_deps_required=( curl wget util-linux python3 file tar gzip bzip2 unzip binutils bc jq tmux )
+			array_deps_required=( curl wget util-linux python3 file tar gzip bzip2 unzip binutils bc jq tmux nmap-ncat )
 	elif [[ "${distroname}" == *"Amazon Linux AMI"* ]]; then
-			array_deps_required=( curl wget util-linux python3 file tar gzip bzip2 unzip binutils bc jq tmux )
+			array_deps_required=( curl wget util-linux python3 file tar gzip bzip2 unzip binutils bc jq tmux nmap-ncat )
 	else
-		array_deps_required=( curl wget util-linux python3 file tar gzip bzip2 unzip binutils bc jq tmux )
+		array_deps_required=( curl wget util-linux python3 file tar gzip bzip2 unzip binutils bc jq tmux nmap-ncat )
 	fi
 
 	# All servers except ts3, mumble, multi theft auto and minecraft servers require glibc.i686 and libstdc++.i686.

--- a/lgsm/functions/fix_ark.sh
+++ b/lgsm/functions/fix_ark.sh
@@ -4,6 +4,16 @@
 # Website: https://linuxgsm.com
 # Description: Resolves various issues with ARK: Survival Evolved.
 
+# removes the symlink if broken. fixes issue with older versions of LinuxGSM linking to /home/arkserver/steamcmd
+# rather than ${HOME}/.steam. This fix could be deprecated eventually.
+if [ ! -e "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux" ] ; then
+	rm -f "${serverfiles:?}/Engine/Binaries/ThirdParty/SteamCMD/Linux"
+fi
+
+if [ ! -e "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux/steamapps" ] ; then
+	rm -f "${serverfiles:?}/Engine/Binaries/ThirdParty/SteamCMD/Linux/steamapps"
+fi
+
 # Symlinking the SteamCMD directory into the correct ARK directory so that the mods auto-management will work.
 if [ ! -d "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux" ]; then
 	ln -s "${HOME}/.steam/steamcmd" "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux"

--- a/lgsm/functions/fix_ark.sh
+++ b/lgsm/functions/fix_ark.sh
@@ -6,19 +6,19 @@
 
 # removes the symlink if broken. fixes issue with older versions of LinuxGSM linking to /home/arkserver/steamcmd
 # rather than ${HOME}/.steam. This fix could be deprecated eventually.
-if [ ! -e "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux" ] ; then
+if [ ! -e "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux" ]||[ ! -e "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux/steamapps" ]; then
+	fixname="broken steamcmd symlink"
+	fn_fix_msg_start
 	rm -f "${serverfiles:?}/Engine/Binaries/ThirdParty/SteamCMD/Linux"
-fi
-
-if [ ! -e "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux/steamapps" ] ; then
 	rm -f "${serverfiles:?}/Engine/Binaries/ThirdParty/SteamCMD/Linux/steamapps"
+	fn_fix_msg_end
 fi
 
 # Symlinking the SteamCMD directory into the correct ARK directory so that the mods auto-management will work.
-if [ ! -d "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux" ]; then
+if [ ! -d "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux" ]||[ ! -d "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux/steamapps" ]; then
+	fixname="steamcmd symlink"
+	fn_fix_msg_start
 	ln -s "${HOME}/.steam/steamcmd" "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux"
-fi
-
-if [ ! -d "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux/steamapps" ]; then
 	ln -s "${HOME}/Steam/steamapps" "${serverfiles}/Engine/Binaries/ThirdParty/SteamCMD/Linux/steamapps"
+	fn_fix_msg_end
 fi


### PR DESCRIPTION
# Description

Resolve mods failing after updating to linuxgsm v20.1.0. Problem was caused by the symlink point to /home/arkserver/steamcmd which has been removed if the steamcmd apt package is installed.
The fix will remove the symlink if broken and apply the updated working one.

Fixes #2750 

## Type of change

* [x] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [ ] This pull request uses the `develop` branch as its base.
* [ ] This pull request Subject follows the Conventional Commits standard.
* [ ] This code follows the style guidelines of this project.
* [ ] I have performed a self-review of my own code.
* [ ] I have checked that this code is commented where required.
* [ ] I have provided a detailed enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
