### PR TITLE
fix(ark): flags must be different arguments

### DIFF
--- a/lgsm/config-default/config-lgsm/arkserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arkserver/_default.cfg
@@ -19,7 +19,7 @@ maxplayers="70"
 
 ## Server Start Command | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
 fn_parms(){
-parms="\"${defaultmap}?AltSaveDirectoryName=${defaultmap}?listen?MultiHome=${ip}?MaxPlayers=${maxplayers}?QueryPort=${queryport}?RCONPort=${rconport}?Port=${port} -automanagedmods\""
+parms="\"${defaultmap}?AltSaveDirectoryName=${defaultmap}?listen?MultiHome=${ip}?MaxPlayers=${maxplayers}?QueryPort=${queryport}?RCONPort=${rconport}?Port=${port}\" -automanagedmods"
 }
 
 #### LinuxGSM Settings ####


### PR DESCRIPTION
Moves the default "-automanagedmods" flag on ARK out of the server settings string.
Instead, it is put on a new argument (`argv` entry).

I am pretty sure the flag does nothing when it is forced into the connection string.
At least that's how it was when I put argument "-NoBattlEye" in the same string literal, it did not disable battle eye. Moving it to a separate argument did.
This change also goes in line with the server configuration on the ARK gamepedia.
https://ark.gamepedia.com/Server_Configuration

# Description

Please include a summary of the change and which issues are fixed.

Fixes #[issue]

## Type of change

* Bug fix (change which fixes an issue).

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [ ] I have checked If documentation needs updating.