### PR TITLE
fix(ts3server): improve ts3 ip parsing

### DIFF
--- a/lgsm/functions/info_config.sh
+++ b/lgsm/functions/info_config.sh
@@ -826,7 +826,7 @@ fn_info_config_teamspeak3(){
 		queryport=$(grep "query_port" "${servercfgfullpath}" | grep -v "#" | tr -cd '[:digit:]')
 		fileport=$(grep "filetransfer_port" "${servercfgfullpath}" | grep -v "#" | tr -cd '[:digit:]')
 
-		ip=$(grep "voice_ip" "${servercfgfullpath}" | sed -e 's/^[ \t]*//g' -e '/^#/d' -e 's/voice_ip//g' | tr -d '=\";,:' | sed -e 's/^[ \t]*//' -e 's/[ \t]*$//')
+		ip=$(grep "voice_ip" "${servercfgfullpath}" | sed -e 's/^[ \t]*//g' -e '/^#/d' -e 's/voice_ip//g' | sed 's/,.*//' | tr -d '=\";,:' | sed -e 's/^[ \t]*//' -e 's/[ \t]*$//')
 		ipsetinconfig=1
 		ipinconfigvar="voice_ip"
 


### PR DESCRIPTION
For Teamspeak3-Servers: Only use the first IP specified within the ts3server.ini file. The IP string is cut off after the first appearance of a comma (IP seperator within ts3server.ini files).

# Description
As described inte teamspeak server documentation the voice_ip parameter allows a comma separated IP list. Currently when e.g. "voice_ip=12.345.678.910, 1a23:b456:7891:011::1" is specified which is according to ts standards LinuxGSM will extract "12.345.678.910 1a23b45678910111" as IP string and can not deal with it. As a workaround till more then one IP and IPv6 is supported the IP string should be cut off after the first appearance of a comma.

Fixes #2658 

## Type of change

* [x] Bug fix (change which fixes an issue).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
