### PR TITLE
fix: correct and standardise name of goldsrc engine

### DIFF
--- a/lgsm/config-default/config-lgsm/ahl2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ahl2server/_default.cfg
@@ -120,7 +120,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/ahlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ahlserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -140,7 +140,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="Action half-life"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.3.4"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/arkserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arkserver/_default.cfg
@@ -125,7 +125,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/arma3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arma3server/_default.cfg
@@ -139,7 +139,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/bb2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bb2server/_default.cfg
@@ -129,7 +129,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/bbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bbserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -140,7 +140,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="BrainBread"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.3.4"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/bdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bdserver/_default.cfg
@@ -123,7 +123,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -139,7 +139,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="Base Defense"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.14"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/bf1942server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bf1942server/_default.cfg
@@ -108,7 +108,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/bmdmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bmdmserver/_default.cfg
@@ -129,7 +129,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/boserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/boserver/_default.cfg
@@ -122,7 +122,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/bsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bsserver/_default.cfg
@@ -133,7 +133,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/bt1944server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bt1944server/_default.cfg
@@ -121,7 +121,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/btserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/btserver/_default.cfg
@@ -116,7 +116,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="7"
 

--- a/lgsm/config-default/config-lgsm/ccserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ccserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/cod2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cod2server/_default.cfg
@@ -111,7 +111,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/cod4server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cod4server/_default.cfg
@@ -111,7 +111,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/codserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/codserver/_default.cfg
@@ -111,7 +111,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/coduoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/coduoserver/_default.cfg
@@ -111,7 +111,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/codwawserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/codwawserver/_default.cfg
@@ -111,7 +111,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/csczserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csczserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -140,7 +140,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="Counter-Strike: Condition Zero"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.3.6"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -149,7 +149,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/csserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -140,7 +140,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="Counter-Strike 1.6"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.3.6"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/cssserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cssserver/_default.cfg
@@ -129,7 +129,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/dabserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dabserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/dmcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dmcserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -140,7 +140,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="Deathmatch Classic"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.3.4"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/dodserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dodserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -140,7 +140,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="Day of Defeat"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.3.4"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/dodsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dodsserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/doiserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/doiserver/_default.cfg
@@ -125,7 +125,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/dstserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dstserver/_default.cfg
@@ -127,7 +127,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/dysserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dysserver/_default.cfg
@@ -129,7 +129,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/ecoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ecoserver/_default.cfg
@@ -116,7 +116,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/emserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/emserver/_default.cfg
@@ -129,7 +129,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/etlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/etlserver/_default.cfg
@@ -105,7 +105,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/fctrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/fctrserver/_default.cfg
@@ -116,7 +116,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/fofserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/fofserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/gesserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/gesserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/gmodserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/gmodserver/_default.cfg
@@ -140,7 +140,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/hldmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hldmserver/_default.cfg
@@ -123,7 +123,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -139,7 +139,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="Half Life: Deathmatch"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.3.4"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/hldmsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hldmsserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/hwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hwserver/_default.cfg
@@ -135,7 +135,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/insserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/insserver/_default.cfg
@@ -130,7 +130,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/inssserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/inssserver/_default.cfg
@@ -131,7 +131,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/iosserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/iosserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/jc2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jc2server/_default.cfg
@@ -116,7 +116,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/jc3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jc3server/_default.cfg
@@ -116,7 +116,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/kf2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/kf2server/_default.cfg
@@ -122,7 +122,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/kfserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/kfserver/_default.cfg
@@ -128,7 +128,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/l4d2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/l4d2server/_default.cfg
@@ -123,7 +123,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/l4dserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/l4dserver/_default.cfg
@@ -123,7 +123,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/mcbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mcbserver/_default.cfg
@@ -108,7 +108,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="5"
 

--- a/lgsm/config-default/config-lgsm/mcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mcserver/_default.cfg
@@ -114,7 +114,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="5"
 

--- a/lgsm/config-default/config-lgsm/mhserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mhserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/mohaaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mohaaserver/_default.cfg
@@ -110,7 +110,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/mtaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mtaserver/_default.cfg
@@ -109,7 +109,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="4"
 

--- a/lgsm/config-default/config-lgsm/mumbleserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mumbleserver/_default.cfg
@@ -109,7 +109,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/ndserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ndserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
@@ -129,7 +129,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/ns2cserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ns2cserver/_default.cfg
@@ -131,7 +131,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="6"
 

--- a/lgsm/config-default/config-lgsm/ns2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ns2server/_default.cfg
@@ -135,7 +135,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="6"
 

--- a/lgsm/config-default/config-lgsm/nsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/nsserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -140,7 +140,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="Natural Selection"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.3.4"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/onsetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/onsetserver/_default.cfg
@@ -116,7 +116,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/opforserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/opforserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -140,7 +140,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="Half-Life: Opposing Force"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.3.4"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/pcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pcserver/_default.cfg
@@ -116,7 +116,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/pstbsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pstbsserver/_default.cfg
@@ -125,7 +125,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/pvkiiserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pvkiiserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/pzserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pzserver/_default.cfg
@@ -120,7 +120,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/q2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/q2server/_default.cfg
@@ -110,7 +110,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/q3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/q3server/_default.cfg
@@ -110,7 +110,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/qlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qlserver/_default.cfg
@@ -118,7 +118,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/qwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qwserver/_default.cfg
@@ -109,7 +109,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/ricochetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ricochetserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -140,7 +140,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="Ricochet"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.3.4"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/roserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/roserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/rtcwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rtcwserver/_default.cfg
@@ -110,7 +110,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/rustserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rustserver/_default.cfg
@@ -148,7 +148,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/rwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rwserver/_default.cfg
@@ -119,7 +119,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/sampserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sampserver/_default.cfg
@@ -109,7 +109,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/sbotsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sbotsserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/sbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sbserver/_default.cfg
@@ -122,7 +122,7 @@ steammaster="flase"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
@@ -119,7 +119,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="8"
 

--- a/lgsm/config-default/config-lgsm/sfcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sfcserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/sof2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sof2server/_default.cfg
@@ -110,7 +110,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/solserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/solserver/_default.cfg
@@ -111,7 +111,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/squadserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/squadserver/_default.cfg
@@ -121,7 +121,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/ss3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ss3server/_default.cfg
@@ -120,7 +120,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/stserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/stserver/_default.cfg
@@ -126,7 +126,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/svenserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/svenserver/_default.cfg
@@ -123,7 +123,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -139,7 +139,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="Sven Co-op"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.24"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/terrariaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/terrariaserver/_default.cfg
@@ -123,7 +123,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="7"
 

--- a/lgsm/config-default/config-lgsm/tf2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tf2server/_default.cfg
@@ -129,7 +129,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/tfcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tfcserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -140,7 +140,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="Team Fortress Classic"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.3.4"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/ts3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ts3server/_default.cfg
@@ -111,7 +111,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/tsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tsserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -140,7 +140,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="The Specialists"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.3.4"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/tuserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tuserver/_default.cfg
@@ -126,7 +126,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/twserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/twserver/_default.cfg
@@ -123,7 +123,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/untserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/untserver/_default.cfg
@@ -126,7 +126,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/ut2k4server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut2k4server/_default.cfg
@@ -109,7 +109,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/ut3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut3server/_default.cfg
@@ -120,7 +120,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/ut99server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut99server/_default.cfg
@@ -109,7 +109,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/utserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/utserver/_default.cfg
@@ -113,7 +113,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/vsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vsserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="9"
 
@@ -140,7 +140,7 @@ querytype="protocol-valve"
 ## Game Server Details
 # Do not edit
 gamename="Vampire Slayer"
-engine="goldsource"
+engine="goldsrc"
 glibc="2.3.4"
 
 #### Directories ####

--- a/lgsm/config-default/config-lgsm/wetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wetserver/_default.cfg
@@ -105,7 +105,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/wfserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wfserver/_default.cfg
@@ -110,7 +110,7 @@ sleeptime="0.5"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/wurmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wurmserver/_default.cfg
@@ -115,7 +115,7 @@ steammaster="false"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="2"
 

--- a/lgsm/config-default/config-lgsm/zmrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/zmrserver/_default.cfg
@@ -124,7 +124,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/config-default/config-lgsm/zpsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/zpsserver/_default.cfg
@@ -129,7 +129,7 @@ steammaster="true"
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 stopmode="3"
 

--- a/lgsm/functions/command_debug.sh
+++ b/lgsm/functions/command_debug.sh
@@ -67,7 +67,7 @@ if [ "${serverpassword}" ]; then
 	echo -e "${lightblue}Server password:\t${default}${serverpassword}"
 fi
 echo -e "${lightblue}Start parameters:${default}"
-if [ "${engine}" == "source" ]||[ "${engine}" == "goldsource" ]; then
+if [ "${engine}" == "source" ]||[ "${engine}" == "goldsrc" ]; then
 	echo -e "${executable} ${parms} -debug"
 else
 	echo -e "${executable} ${parms}"
@@ -98,7 +98,7 @@ trap fn_lockfile_trap INT
 
 cd "${executabledir}" || exit
 # Note: do not add double quotes to ${executable} ${parms}.
-if [ "${engine}" == "source" ]||[ "${engine}" == "goldsource" ]; then
+if [ "${engine}" == "source" ]||[ "${engine}" == "goldsrc" ]; then
 	${executable} ${parms} -debug
 elif [ "${engine}" == "realvirtuality" ]; then
 	# Arma3 requires semicolons in the module list, which need to

--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -65,15 +65,15 @@ fn_stop_graceful_cmd(){
 	fn_sleep_time
 }
 
-# Attempts graceful shutdown of goldsource using rcon 'quit' command.
+# Attempts graceful shutdown of goldsrc using rcon 'quit' command.
 # There is only a 3 second delay before a forced a tmux shutdown
-# as Goldsource servers 'quit' command does a restart rather than shutdown.
-fn_stop_graceful_goldsource(){
+# as GoldSrc servers 'quit' command does a restart rather than shutdown.
+fn_stop_graceful_goldsrc(){
 	fn_print_dots "Graceful: sending \"quit\""
 	fn_script_log_info "Graceful: sending \"quit\""
 	# sends quit
 	tmux send -t "${selfname}" quit ENTER > /dev/null 2>&1
-	# Waits 3 seconds as goldsource servers restart with the quit command.
+	# Waits 3 seconds as goldsrc servers restart with the quit command.
 	for seconds in {1..3}; do
 		sleep 1
 		fn_print_dots "Graceful: sending \"quit\": ${seconds}"
@@ -199,7 +199,7 @@ fn_stop_graceful_select(){
 	elif [ "${stopmode}" == "8" ]; then
 		fn_stop_graceful_sdtd
 	elif [ "${stopmode}" == "9" ]; then
-		fn_stop_graceful_goldsource
+		fn_stop_graceful_goldsrc
 	fi
 }
 

--- a/lgsm/functions/info_config.sh
+++ b/lgsm/functions/info_config.sh
@@ -1460,7 +1460,7 @@ elif [ "${shortname}" == "sol" ]; then
 elif [ "${shortname}" == "sof2" ]; then
 	fn_info_config_sof2
 # Source Engine Games
-elif [ "${engine}" == "source" ]||[ "${engine}" == "goldsource" ]; then
+elif [ "${engine}" == "source" ]||[ "${engine}" == "goldsrc" ]; then
 	fn_info_config_source
 # Starbound
 elif [ "${shortname}" == "sb" ]; then

--- a/lgsm/functions/info_messages.sh
+++ b/lgsm/functions/info_messages.sh
@@ -553,7 +553,7 @@ fn_info_message_ports(){
 		fi
 	done
 	# engines/games that require editing the parms.
-	local ports_edit_array=( "goldsource" "Factorio" "Hurtworld" "iw3.0" "ioquake3" "qfusion" "Rust" "Soldat" "spark" "source" "starbound" "unreal4" "realvirtuality" "Unturned" )
+	local ports_edit_array=( "goldsrc" "Factorio" "Hurtworld" "iw3.0" "ioquake3" "qfusion" "Rust" "Soldat" "spark" "source" "starbound" "unreal4" "realvirtuality" "Unturned" )
 	for port_edit in "${ports_edit_array[@]}"
 	do
 		if [ "${engine}" == "${port_edit}" ]||[ "${gamename}" == "${port_edit}" ]||[ "${shortname}" == "${port_edit}" ]; then
@@ -749,7 +749,7 @@ fn_info_message_factorio(){
 	} | column -s $'\t' -t
 }
 
-fn_info_message_goldsource(){
+fn_info_message_goldsrc(){
 	echo -e "netstat -atunp | grep hlds_linux"
 	echo -e ""
 	{
@@ -1468,8 +1468,8 @@ fn_info_message_select_engine(){
 		fn_info_message_risingworld
 	elif [ "${shortname}" == "wet" ]; then
 		fn_info_message_wolfensteinenemyterritory
-	elif [ "${engine}" == "goldsource" ]; then
-		fn_info_message_goldsource
+	elif [ "${engine}" == "goldsrc" ]; then
+		fn_info_message_goldsrc
 	elif [ "${engine}" == "source" ]; then
 		fn_info_message_source
 	elif [ "${engine}" == "spark" ]; then

--- a/lgsm/functions/info_parms.sh
+++ b/lgsm/functions/info_parms.sh
@@ -284,7 +284,7 @@ elif [ "${shortname}" == "sol" ]; then
 # Serious Sam
 elif [ "${shortname}" == "ss3" ]; then
 	fn_info_parms_ss3
-elif [ "${engine}" == "source" ]||[ "${engine}" == "goldsource" ]; then
+elif [ "${engine}" == "source" ]||[ "${engine}" == "goldsrc" ]; then
 	fn_info_parms_source
 # Spark
 elif [ "${engine}" == "spark" ]; then

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -113,7 +113,7 @@ fn_install_server_files_steamcmd(){
 					local exitcode=$?
 				fi
 			elif [ "${counter}" -ge "5" ]; then
-				if [ "${engine}" == "goldsource" ]; then
+				if [ "${engine}" == "goldsrc" ]; then
 					${unbuffer} ${steamcmdcommand} +login "${steamuser}" "${steampass}" +force_install_dir "${serverfiles}" +app_set_config 90 mod "${appidmod}" +app_update "${appid}" -beta "${branch}" validate +quit
 					local exitcode=$?
 				else
@@ -128,10 +128,10 @@ fn_install_server_files_steamcmd(){
 		fi
 	done
 
-	# Goldsource servers commonly fail to download all the server files required.
+	# GoldSrc servers commonly fail to download all the server files required.
 	# Validating a few of times may reduce the chance of this issue.
-	if [ "${engine}" == "goldsource" ]; then
-		fn_print_information_nl "Goldsource servers commonly fail to download all the server files required. Validating a few of times may reduce the chance of this issue."
+	if [ "${engine}" == "goldsrc" ]; then
+		fn_print_information_nl "GoldSrc servers commonly fail to download all the server files required. Validating a few of times may reduce the chance of this issue."
 		counter="0"
 		while [ "${counter}" -le "4" ]; do
 			counter=$((counter+1))

--- a/lgsm/functions/query_gsquery.py
+++ b/lgsm/functions/query_gsquery.py
@@ -17,7 +17,7 @@ class gsquery:
         self.server_response_timeout = 5
         self.default_buffer_length = 1024
         #
-        sourcequery=['protocol-valve','avalanche3.0','barotrauma','madness','quakelive','realvirtuality','refractor','source','goldsource','spark','starbound','unity3d','unreal4','wurm']
+        sourcequery=['protocol-valve','avalanche3.0','barotrauma','madness','quakelive','realvirtuality','refractor','source','goldsrc','spark','starbound','unity3d','unreal4','wurm']
         idtech2query=['protocol-quake3','idtech2','quake','iw2.0']
         idtech3query=['protocol-quake3','iw3.0','ioquake3','qfusion']
         minecraftquery=['minecraft','lwjgl2']

--- a/tests/tests_defaultcfg/defaultcfg_1.txt
+++ b/tests/tests_defaultcfg/defaultcfg_1.txt
@@ -39,7 +39,7 @@
 # 6: q
 # 7: exit
 # 8: 7 Days to Die
-# 9: Gold Source
+# 9: GoldSrc
 # 10: Teamspeak 3
 ## Game Server Details
 # Do not edit


### PR DESCRIPTION
# Description

GoldSrc servers were named variants of Gold Source. Now using correct engine name "GoldSrc"

Fixes #[issue]

## Type of change

* [ ] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [x] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
