### PR TITLE
remove appinfo.vdf correctly

### DIFF
--- a/lgsm/config-default/config-lgsm/acserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/acserver/_default.cfg
@@ -137,7 +137,7 @@ querytype=""
 # Do not edit
 gamename="Assetto Corsa"
 engine="unity3d"
-glibc=""
+glibc="2.15"
 
 #### Directories ####
 # Edit with care

--- a/lgsm/functions/update_steamcmd.sh
+++ b/lgsm/functions/update_steamcmd.sh
@@ -48,8 +48,8 @@ fn_update_steamcmd_localbuild(){
 	localbuild=$(grep buildid "${appmanifestfile}" | tr '[:blank:]"' ' ' | tr -s ' ' | cut -d\  -f3)
 
 	# Removes appinfo.vdf as a fix for not always getting up to date version info from SteamCMD.
-	if [ -f "${HOME}/Steam/appcache/appinfo.vdf" ]; then
-		rm -f "${HOME}/Steam/appcache/appinfo.vdf"
+	if [ -f "${HOME}/.steam/appcache/appinfo.vdf" ]; then
+		rm -f "${HOME}/.steam/appcache/appinfo.vdf"
 	fi
 
 	# Set branch for updateinfo.


### PR DESCRIPTION
# Description

appinfo.vdf has been moved to {HOME}/.steam/appcache directory when it was before in {HOME}/Steam/appcache but it hasn't yet been updated in the update script. If we don't delete this file before checking for updates, SteamCMD might not fetch the most up to date BuildID.
I noticed this with the latest csgo update with a freshly installed server when "./csgoserver update" command said that the server is up to date when it wasn't and I needed to use "./csgoserver force-update" command to update it.

## Type of change

* [x] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [x] I have checked If documentation needs updating.
