### PR TITLE
feat(install): convert non-steamcmd game srvers to use tar.xz

### DIFF
--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -368,8 +368,8 @@ fn_deps_build_debian(){
 	# 7 Days to Die
 	elif [ "${shortname}" == "sdtd" ]; then
 		array_deps_required+=( telnet expect )
-		# Battlefield 1942, Counter-Strike: Source, Garry's Mod, No More Room in Hell, Source Forts Classic and Zombie Panic: Source
-		elif [ "${shortname}" == "bf1942" ]||[ "${shortname}" == "css" ]||[ "${shortname}" == "gmod" ]||[ "${shortname}" == "nmrih" ]||[ "${shortname}" == "sfc" ]||[ "${shortname}" == "zps" ]; then
+		# Battlefield 1942, Counter-Strike: Source, Garry's Mod, No More Room in Hell, Source Forts Classic, Zombie Master Reborn and Zombie Panic: Source
+	elif [ "${shortname}" == "bf1942" ]||[ "${shortname}" == "css" ]||[ "${shortname}" == "gmod" ]||[ "${shortname}" == "nmrih" ]||[ "${shortname}" == "sfc" ]||[ "${shortname}" == "zmr" ]||[ "${shortname}" == "zps" ]; then
 		if [ "${arch}" == "x86_64" ]; then
 			array_deps_required+=( libtinfo5:i386 )
 		else
@@ -480,8 +480,8 @@ fn_deps_build_redhat(){
 	# 7 Days to Die
 	elif [ "${shortname}" == "sdtd" ]; then
 		array_deps_required+=( telnet expect )
-		# Battlefield 1942, Counter-Strike: Source, Garry's Mod, No More Room in Hell, Source Forts Classic and Zombie Panic: Source
-		elif [ "${shortname}" == "bf1942" ]||[ "${shortname}" == "css" ]||[ "${shortname}" == "gmod" ]||[ "${shortname}" == "nmrih" ]||[ "${shortname}" == "sfc" ]||[ "${shortname}" == "zps" ]; then
+		# Battlefield 1942, Counter-Strike: Source, Garry's Mod, No More Room in Hell, Source Forts Classic, Zombie Master Reborn and Zombie Panic: Source
+	elif [ "${shortname}" == "bf1942" ]||[ "${shortname}" == "css" ]||[ "${shortname}" == "gmod" ]||[ "${shortname}" == "nmrih" ]||[ "${shortname}" == "sfc" ]||[ "${shortname}" == "zmr" ]||[ "${shortname}" == "zps" ]; then
 			array_deps_required+=( ncurses-libs.i686 )
 	# Brainbread 2, Don't Starve Together & Team Fortress 2
 	elif [ "${shortname}" == "bb2" ]||[ "${shortname}" == "dst" ]||[ "${shortname}" == "tf2" ]; then

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -368,8 +368,8 @@ fn_deps_build_debian(){
 	# 7 Days to Die
 	elif [ "${shortname}" == "sdtd" ]; then
 		array_deps_required+=( telnet expect )
-	# No More Room in Hell, Counter-Strike: Source, Garry's Mod and Zombie Panic: Source
-	elif [ "${shortname}" == "nmrih" ]||[ "${shortname}" == "css" ]||[ "${shortname}" == "gmod" ]||[ "${shortname}" == "zps" ]; then
+		# Battlefield 1942, Counter-Strike: Source, Garry's Mod, No More Room in Hell, Source Forts Classic and Zombie Panic: Source
+		elif [ "${shortname}" == "bf1942" ]||[ "${shortname}" == "css" ]||[ "${shortname}" == "gmod" ]||[ "${shortname}" == "nmrih" ]||[ "${shortname}" == "sfc" ]||[ "${shortname}" == "zps" ]; then
 		if [ "${arch}" == "x86_64" ]; then
 			array_deps_required+=( libtinfo5:i386 )
 		else
@@ -381,9 +381,6 @@ fn_deps_build_debian(){
 		if [ "${shortname}" == "tf2" ]; then
 			array_deps_required+=( libtcmalloc-minimal4:i386 )
 		fi
-	# Battlefield: 1942
-	elif [ "${shortname}" == "bf1942" ]; then
-		array_deps_required+=( libncurses5:i386 )
 	# Call of Duty & Medal of Honor: Allied Assault
 	elif [ "${shortname}" == "cod" ]||[ "${shortname}" == "coduo" ]||[ "${shortname}" == "cod2" ]||[ "${shortname}" == "mohaa" ]; then
 		array_deps_required+=( libstdc++5:i386 )
@@ -483,18 +480,15 @@ fn_deps_build_redhat(){
 	# 7 Days to Die
 	elif [ "${shortname}" == "sdtd" ]; then
 		array_deps_required+=( telnet expect )
-	# No More Room in Hell, Counter-Strike: Source, Garry's Mod and Zombie Panic: Source
-	elif [ "${shortname}" == "nmrih" ]||[ "${shortname}" == "css" ]||[ "${shortname}" == "gmod" ]||[ "${shortname}" == "zps" ]; then
-		array_deps_required+=( ncurses-libs.i686 )
+		# Battlefield 1942, Counter-Strike: Source, Garry's Mod, No More Room in Hell, Source Forts Classic and Zombie Panic: Source
+		elif [ "${shortname}" == "bf1942" ]||[ "${shortname}" == "css" ]||[ "${shortname}" == "gmod" ]||[ "${shortname}" == "nmrih" ]||[ "${shortname}" == "sfc" ]||[ "${shortname}" == "zps" ]; then
+			array_deps_required+=( ncurses-libs.i686 )
 	# Brainbread 2, Don't Starve Together & Team Fortress 2
 	elif [ "${shortname}" == "bb2" ]||[ "${shortname}" == "dst" ]||[ "${shortname}" == "tf2" ]; then
 		array_deps_required+=( libcurl.i686 )
 		if [ "${shortname}" == "tf2" ]; then
 			array_deps_required+=( gperftools-libs.i686 )
 		fi
-	# Battlefield: 1942
-	elif [ "${shortname}" == "bf1942" ]; then
-		array_deps_required+=( ncurses-libs.i686 )
 	# Call of Duty & Medal of Honor: Allied Assault
 	elif [ "${shortname}" == "cod" ]||[ "${shortname}" == "coduo" ]||[ "${shortname}" == "cod2" ]||[ "${shortname}" == "mohaa" ]; then
 		array_deps_required+=( compat-libstdc++-33.i686 )

--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -220,10 +220,10 @@ fn_deps_email(){
 }
 
 fn_found_missing_deps(){
-	if [ "${#array_deps_missing[@]}" != "0" ]; then
+	if [ "${#array_deps_missing[*]}" != "0" ]; then
 
-		fn_print_warning_nl "Missing dependencies: ${red}${array_deps_missing[@]}${default}"
-		fn_script_log_warn "Missing dependencies: ${array_deps_missing[@]}"
+		fn_print_warning_nl "Missing dependencies: ${red}${array_deps_missing[*]}${default}"
+		fn_script_log_warn "Missing dependencies: ${array_deps_missing[*]}"
 		fn_sleep_time
 		if [ "${monostatus}" ]; then
 			fn_install_mono_repo
@@ -248,13 +248,13 @@ fn_found_missing_deps(){
 			sleep 1
 			echo -en "   \r"
 			if [ "$(command -v dpkg-query 2>/dev/null)" ]; then
-				cmd="echo steamcmd steam/question select \"I AGREE\" | sudo debconf-set-selections; echo steamcmd steam/license note '' | sudo debconf-set-selections; sudo dpkg --add-architecture i386; sudo apt update; sudo apt -y install ${array_deps_missing[@]}"
+				cmd="echo steamcmd steam/question select \"I AGREE\" | sudo debconf-set-selections; echo steamcmd steam/license note '' | sudo debconf-set-selections; sudo dpkg --add-architecture i386; sudo apt update; sudo apt -y install ${array_deps_missing[*]}"
 				eval "${cmd}"
 			elif [ "$(command -v dnf 2>/dev/null)" ]; then
-				cmd="sudo dnf -y install ${array_deps_missing[@]}"
+				cmd="sudo dnf -y install ${array_deps_missing[*]}"
 				eval "${cmd}"
 			elif [ "$(command -v yum 2>/dev/null)" ]; then
-				cmd="sudo yum -y install ${array_deps_missing[@]}"
+				cmd="sudo yum -y install ${array_deps_missing[*]}"
 				eval "${cmd}"
 			fi
 			if [ $? != 0 ]; then
@@ -264,11 +264,11 @@ fn_found_missing_deps(){
 				fn_print_warning_nl "Manually install dependencies."
 				fn_script_log_warn "Manually install dependencies."
 				if [ "$(command -v dpkg-query 2>/dev/null)" ]; then
-					echo -e "	sudo dpkg --add-architecture i386; sudo apt update; sudo apt install ${array_deps_missing[@]}"
+					echo -e "	sudo dpkg --add-architecture i386; sudo apt update; sudo apt install ${array_deps_missing[*]}"
 				elif [ "$(command -v dnf 2>/dev/null)" ]; then
-					echo -e "	sudo dnf install ${array_deps_missing[@]}"
+					echo -e "	sudo dnf install ${array_deps_missing[*]}"
 				elif [ "$(command -v yum 2>/dev/null)" ]; then
-					echo -e "	sudo yum install ${array_deps_missing[@]}"
+					echo -e "	sudo yum install ${array_deps_missing[*]}"
 				fi
 				if [ "${steamcmdfail}" ]; then
 					echo -e ""
@@ -290,11 +290,11 @@ fn_found_missing_deps(){
 			fn_script_log_warn "$(whoami) does not have sudo access. Manually install dependencies."
 			echo -e ""
 			if [ "$(command -v dpkg-query 2>/dev/null)" ]; then
-				echo -e "sudo dpkg --add-architecture i386; sudo apt update; sudo apt install ${array_deps_missing[@]}"
+				echo -e "sudo dpkg --add-architecture i386; sudo apt update; sudo apt install ${array_deps_missing[*]}"
 			elif [ "$(command -v dnf 2>/dev/null)" ]; then
-				echo -e "sudo dnf install ${array_deps_missing[@]}"
+				echo -e "sudo dnf install ${array_deps_missing[*]}"
 			elif [ "$(command -v yum 2>/dev/null)" ]; then
-				echo -e "sudo yum install ${array_deps_missing[@]}"
+				echo -e "sudo yum install ${array_deps_missing[*]}"
 			fi
 			if [ "${steamcmdfail}" ]; then
 				echo -e ""
@@ -322,7 +322,7 @@ fn_found_missing_deps(){
 
 fn_check_loop(){
 	# Loop though required depenencies.
-	for deptocheck in "${array_deps_required[@]}"
+	for deptocheck in ${array_deps_required[*]}
 	do
 		fn_deps_detector
 	done
@@ -482,7 +482,7 @@ fn_deps_build_redhat(){
 		array_deps_required+=( telnet expect )
 		# Battlefield 1942, Counter-Strike: Source, Garry's Mod, No More Room in Hell, Source Forts Classic, Zombie Master Reborn and Zombie Panic: Source
 	elif [ "${shortname}" == "bf1942" ]||[ "${shortname}" == "css" ]||[ "${shortname}" == "gmod" ]||[ "${shortname}" == "nmrih" ]||[ "${shortname}" == "sfc" ]||[ "${shortname}" == "zmr" ]||[ "${shortname}" == "zps" ]; then
-			array_deps_required+=( ncurses-libs.i686 )
+		array_deps_required+=( ncurses-libs.i686 )
 	# Brainbread 2, Don't Starve Together & Team Fortress 2
 	elif [ "${shortname}" == "bb2" ]||[ "${shortname}" == "dst" ]||[ "${shortname}" == "tf2" ]; then
 		array_deps_required+=( libcurl.i686 )

--- a/lgsm/functions/command_backup.sh
+++ b/lgsm/functions/command_backup.sh
@@ -143,7 +143,7 @@ fn_backup_compression(){
 	if [ ${exitcode} -ne 0 ]; then
 		fn_print_fail_eol
 		fn_script_log_fatal "Backup in progress: FAIL"
-		echo -e "${tarcmd}" | tee -a "${lgsmlog}"
+		echo -e "${extractcmd}" | tee -a "${lgsmlog}"
 		fn_print_fail_nl "Starting backup"
 		fn_script_log_fatal "Starting backup"
 	else

--- a/lgsm/functions/core_dl.sh
+++ b/lgsm/functions/core_dl.sh
@@ -77,9 +77,9 @@ fn_dl_extract(){
 	if [ "${mime}" == "application/gzip" ]||[ "${mime}" == "application/x-gzip" ]; then
 		extractcmd=$(tar -zxf "${local_filedir}/${local_filename}" -C "${extractdir}")
 	elif [ "${mime}" == "application/x-bzip2" ]; then
-		tarcmd=$(tar -jxf "${local_filedir}/${local_filename}" -C "${extractdir}")
+		extractcmd=$(tar -jxf "${local_filedir}/${local_filename}" -C "${extractdir}")
 	elif [ "${mime}" == "application/x-xz" ]; then
-		tarcmd=$(tar -xf "${local_filedir}/${local_filename}" -C "${extractdir}")
+		extractcmd=$(tar -xf "${local_filedir}/${local_filename}" -C "${extractdir}")
 	elif [ "${mime}" == "application/zip" ]; then
 		extractcmd=$(unzip -qo -d "${extractdir}" "${local_filedir}/${local_filename}")
 	fi

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -20,7 +20,7 @@ fn_install_server_files(){
 	elif [ "${shortname}" == "coduo" ]; then
 		remote_fileurl="http://linuxgsm.download/CallOfDutyUnitedOffensive/coduo-lnxded-1.51b-full.tar.xz"; local_filedir="${tmpdir}"; local_filename="coduo-lnxded-1.51b-full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="35cabccd67adcda44aaebc59405915b9"
 	elif [ "${shortname}" == "cod2" ]; then
-		remote_fileurl="http://linuxgsm.download/CallOfDuty2/cod2-lnxded-1.3-full.tar.xz"; local_filedir="${tmpdir}"; local_filename="cod2-lnxded-1.3-full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="35cabccd67adcda44aaebc59405915b9"
+		remote_fileurl="http://linuxgsm.download/CallOfDuty2/cod2-lnxded-1.3-full.tar.xz"; local_filedir="${tmpdir}"; local_filename="cod2-lnxded-1.3-full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="b8c4c611f01627dd43348e78478a3d41"
 	elif [ "${shortname}" == "cod4" ]; then
 		remote_fileurl="http://linuxgsm.download/CallOfDuty4/cod4x18_1772_dedrun.tar.xz"; local_filedir="${tmpdir}"; local_filename="cod4x18_1772_dedrun.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="de29f29d79f9cc24574b838daa501e46"
 	elif [ "${shortname}" == "codwaw" ]; then

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -22,11 +22,11 @@ fn_install_server_files(){
 	elif [ "${shortname}" == "cod2" ]; then
 		remote_fileurl="http://linuxgsm.download/CallOfDuty2/cod2-lnxded-1.3-full.tar.xz"; local_filedir="${tmpdir}"; local_filename="cod2-lnxded-1.3-full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="b8c4c611f01627dd43348e78478a3d41"
 	elif [ "${shortname}" == "cod4" ]; then
-		remote_fileurl="http://linuxgsm.download/CallOfDuty4/cod4x18_1772_dedrun.tar.xz"; local_filedir="${tmpdir}"; local_filename="cod4x18_1772_dedrun.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="9e14f44be23a8068352e837c783db573"
+		remote_fileurl="http://linuxgsm.download/CallOfDuty4/cod4x18_1790_lnxded.tar.xz"; local_filedir="${tmpdir}"; local_filename="cod4x18_1790_lnxded.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="30609db2afde09d22498fbab3a427d11"
 	elif [ "${shortname}" == "codwaw" ]; then
 		remote_fileurl="http://linuxgsm.download/CallOfDutyWorldAtWar/codwaw-lnxded-1.7-full.tar.xz"; local_filedir="${tmpdir}"; local_filename="codwaw-lnxded-1.7-full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="2c6be1bb66ea631b9b2e7ae6216c6680"
 	elif [ "${shortname}" == "etl" ]; then
-		remote_fileurl="http://linuxgsm.download/WolfensteinEnemyTerritory/etlegacy-v2.75-i386-et-260b.tar.bz2"; local_filedir="${tmpdir}"; local_filename="etlegacy-v2.75-i386-et-260b.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="92d7d4c26e0a295daed78cef623eeabb"
+		remote_fileurl="http://linuxgsm.download/WolfensteinEnemyTerritory/etlegacy-v2.76-i386-et-260b.tar.xz"; local_filedir="${tmpdir}"; local_filename="etlegacy-v2.75-i386-et-260b.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="178a00233cec1e25b69d130107ce1a79"
 	elif [ "${shortname}" == "ges" ]; then
 		remote_fileurl="http://linuxgsm.download/GoldenEyeSource/GoldenEye_Source_v5.0.6_full_server.tar.xz"; local_filedir="${tmpdir}"; local_filename="GoldenEye_Source_v5.0.6_full_server.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="e31481f280eed40c9145816bd4f6dc45"
 	elif [ "${shortname}" == "mohaa" ]; then

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -52,7 +52,7 @@ fn_install_server_files(){
 	elif [ "${shortname}" == "ut99" ]; then
 		remote_fileurl="http://linuxgsm.download/UnrealTournament99/ut99-server-451-ultimate-linux.tar.xz"; local_filedir="${tmpdir}"; local_filename="ut99-server-451-ultimate-linux.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="42c6839f8cb95907eeef71a1838aa1f7"
 	elif [ "${shortname}" == "ut" ]; then
-		remote_fileurl="http://linuxgsm.download/UnrealTournament/UnrealTournament-Server-XAN-3525360-Linux.zip"; local_filedir="${tmpdir}"; local_filename="UnrealTournament-Server-XAN-3525360-Linux.zip";  chmodx="noexecute" run="norun"; force="noforce"; md5="cad730ad6793ba6261f9a341ad7396eb"
+		remote_fileurl="http://linuxgsm.download/UnrealTournament/UnrealTournament-Server-XAN-3525360-Linux.tar.xz"; local_filedir="${tmpdir}"; local_filename="UnrealTournament-Server-XAN-3525360-Linux.zip";  chmodx="noexecute" run="norun"; force="noforce"; md5="41dd92015713a78211eaccf503b72393"
 	elif [ "${shortname}" == "ut3" ]; then
 		remote_fileurl="http://linuxgsm.download/UnrealTournament3/UT3-linux-server-2.1.tar.xz"; local_filedir="${tmpdir}"; local_filename="UT3-linux-server-2.1.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="6b92b083c7ab416399e2183a22fda1df"
 	elif [ "${shortname}" == "vs" ]; then

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -52,7 +52,7 @@ fn_install_server_files(){
 	elif [ "${shortname}" == "ut99" ]; then
 		remote_fileurl="http://linuxgsm.download/UnrealTournament99/ut99-server-451-ultimate-linux.tar.xz"; local_filedir="${tmpdir}"; local_filename="ut99-server-451-ultimate-linux.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="42c6839f8cb95907eeef71a1838aa1f7"
 	elif [ "${shortname}" == "ut" ]; then
-		remote_fileurl="http://linuxgsm.download/UnrealTournament/UnrealTournament-Server-XAN-3525360-Linux.tar.xz"; local_filedir="${tmpdir}"; local_filename="UnrealTournament-Server-XAN-3525360-Linux.tar.xz";  chmodx="noexecute" run="norun"; force="noforce"; md5="8876cca61e3f83ea08db25208bde6ac6"
+		remote_fileurl="http://linuxgsm.download/UnrealTournament/UnrealTournament-Server-XAN-3525360-Linux.tar.xz"; local_filedir="${tmpdir}"; local_filename="UnrealTournament-Server-XAN-3525360-Linux.tar.xz";  chmodx="noexecute" run="norun"; force="noforce"; md5="41dd92015713a78211eaccf503b72393"
 	elif [ "${shortname}" == "ut3" ]; then
 		remote_fileurl="http://linuxgsm.download/UnrealTournament3/UT3-linux-server-2.1.tar.xz"; local_filedir="${tmpdir}"; local_filename="UT3-linux-server-2.1.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="6b92b083c7ab416399e2183a22fda1df"
 	elif [ "${shortname}" == "vs" ]; then

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -22,7 +22,7 @@ fn_install_server_files(){
 	elif [ "${shortname}" == "cod2" ]; then
 		remote_fileurl="http://linuxgsm.download/CallOfDuty2/cod2-lnxded-1.3-full.tar.xz"; local_filedir="${tmpdir}"; local_filename="cod2-lnxded-1.3-full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="b8c4c611f01627dd43348e78478a3d41"
 	elif [ "${shortname}" == "cod4" ]; then
-		remote_fileurl="http://linuxgsm.download/CallOfDuty4/cod4x18_1772_dedrun.tar.xz"; local_filedir="${tmpdir}"; local_filename="cod4x18_1772_dedrun.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="de29f29d79f9cc24574b838daa501e46"
+		remote_fileurl="http://linuxgsm.download/CallOfDuty4/cod4x18_1772_dedrun.tar.xz"; local_filedir="${tmpdir}"; local_filename="cod4x18_1772_dedrun.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="9e14f44be23a8068352e837c783db573"
 	elif [ "${shortname}" == "codwaw" ]; then
 		remote_fileurl="http://linuxgsm.download/CallOfDutyWorldAtWar/codwaw-lnxded-1.7-full.tar.xz"; local_filedir="${tmpdir}"; local_filename="codwaw-lnxded-1.7-full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="2c6be1bb66ea631b9b2e7ae6216c6680"
 	elif [ "${shortname}" == "etl" ]; then

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -10,59 +10,59 @@ local function_selfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 fn_install_server_files(){
 	if [ "${shortname}" == "ahl" ]; then
-		remote_fileurl="http://linuxgsm.download/ActionHalfLife/action_halflife-1.0.tar.bz2"; local_filedir="${tmpdir}"; local_filename="action_halflife-1.0.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="31430e670692b2eeaa0d1217db4dcb73"
+		remote_fileurl="http://linuxgsm.download/ActionHalfLife/action_halflife-1.0.tar.zx"; local_filedir="${tmpdir}"; local_filename="action_halflife-1.0.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="61d7b79fd714888b6d65944fdaafa94a"
 	elif [ "${shortname}" == "bf1942" ]; then
-		remote_fileurl="http://linuxgsm.download/BattleField1942/bf1942_lnxded-1.61-hacked-to-1.612.full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="bf1942_lnxded-1.61-hacked-to-1.612.full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="a86a5d3cd64ca59abcc9bb9f777c2e5d"
+		remote_fileurl="http://linuxgsm.download/BattleField1942/bf1942_lnxded-1.61-hacked-to-1.612.full.tar.xz"; local_filedir="${tmpdir}"; local_filename="bf1942_lnxded-1.61-hacked-to-1.612.full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="4223bf4ed85f5162c24b2cba51249b9e"
 	elif [ "${shortname}" == "bb" ]; then
-		remote_fileurl="http://linuxgsm.download/BrainBread/brainbread-v1.2-linuxserver.tar.bz2"; local_filedir="${tmpdir}"; local_filename="brainbread-v1.2-linuxserver.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="5c729a7e9eecfa81b71a6a1f7267f0fd"
+		remote_fileurl="http://linuxgsm.download/BrainBread/brainbread-v1.2-linuxserver.tar.xz"; local_filedir="${tmpdir}"; local_filename="brainbread-v1.2-linuxserver.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="55f227183b736397806d5b6db6143f15"
 	elif [ "${shortname}" == "cod" ]; then
-		remote_fileurl="http://linuxgsm.download/CallOfDuty/cod-lnxded-1.5b-full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="cod-lnxded-1.5-large.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="19629895a4cf6fd8f6d1ee198b5304cd"
+		remote_fileurl="http://linuxgsm.download/CallOfDuty/cod-lnxded-1.5b-full.tar.xz"; local_filedir="${tmpdir}"; local_filename="cod-lnxded-1.5-large.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="ee0ad1ccbfa1fd27fde01a4a431a5c2f"
 	elif [ "${shortname}" == "coduo" ]; then
-		remote_fileurl="http://linuxgsm.download/CallOfDutyUnitedOffensive/coduo-lnxded-1.51b-full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="coduo-lnxded-1.51b-full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="f1804ef13036e2b4ab535db000b19e97"
+		remote_fileurl="http://linuxgsm.download/CallOfDutyUnitedOffensive/coduo-lnxded-1.51b-full.tar.xz"; local_filedir="${tmpdir}"; local_filename="coduo-lnxded-1.51b-full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="35cabccd67adcda44aaebc59405915b9"
 	elif [ "${shortname}" == "cod2" ]; then
-		remote_fileurl="http://linuxgsm.download/CallOfDuty2/cod2-lnxded-1.3-full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="cod2-lnxded-1.3-full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="078128f83d06dc3d7699428dc2870214"
+		remote_fileurl="http://linuxgsm.download/CallOfDuty2/cod2-lnxded-1.3-full.tar.xz"; local_filedir="${tmpdir}"; local_filename="cod2-lnxded-1.3-full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="35cabccd67adcda44aaebc59405915b9"
 	elif [ "${shortname}" == "cod4" ]; then
-		remote_fileurl="http://linuxgsm.download/CallOfDuty4/cod4x18_1772_dedrun.tar.bz2"; local_filedir="${tmpdir}"; local_filename="cod4x18_1772_dedrun.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="de29f29d79f9cc24574b838daa501e46"
+		remote_fileurl="http://linuxgsm.download/CallOfDuty4/cod4x18_1772_dedrun.tar.xz"; local_filedir="${tmpdir}"; local_filename="cod4x18_1772_dedrun.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="de29f29d79f9cc24574b838daa501e46"
 	elif [ "${shortname}" == "codwaw" ]; then
-		remote_fileurl="http://linuxgsm.download/CallOfDutyWorldAtWar/codwaw-lnxded-1.7-full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="codwaw-lnxded-1.7-full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="0489697ff3bf678c109bfb377d1b7895"
+		remote_fileurl="http://linuxgsm.download/CallOfDutyWorldAtWar/codwaw-lnxded-1.7-full.tar.xz"; local_filedir="${tmpdir}"; local_filename="codwaw-lnxded-1.7-full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="2c6be1bb66ea631b9b2e7ae6216c6680"
 	elif [ "${shortname}" == "etl" ]; then
 		remote_fileurl="http://linuxgsm.download/WolfensteinEnemyTerritory/etlegacy-v2.75-i386-et-260b.tar.bz2"; local_filedir="${tmpdir}"; local_filename="etlegacy-v2.75-i386-et-260b.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="92d7d4c26e0a295daed78cef623eeabb"
 	elif [ "${shortname}" == "ges" ]; then
-		remote_fileurl="http://linuxgsm.download/GoldenEyeSource/GoldenEye_Source_v5.0.6_full_server.tar.bz2"; local_filedir="${tmpdir}"; local_filename="GoldenEye_Source_v5.0.6_full_server.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="c45c16293096706e8b5e2cd64a6f2931"
+		remote_fileurl="http://linuxgsm.download/GoldenEyeSource/GoldenEye_Source_v5.0.6_full_server.tar.xz"; local_filedir="${tmpdir}"; local_filename="GoldenEye_Source_v5.0.6_full_server.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="e31481f280eed40c9145816bd4f6dc45"
 	elif [ "${shortname}" == "mohaa" ]; then
-		remote_fileurl="http://linuxgsm.download/MedalofHonorAlliedAssault/moh_revival_v1.12_RC3.5.1.tar.bz2"; local_filedir="${tmpdir}"; local_filename="moh_revival_v1.12_RC3.5.1.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="9d5924486a0cf5e46dd063216aad05c1"
+		remote_fileurl="http://linuxgsm.download/MedalofHonorAlliedAssault/moh_revival_v1.12_RC3.5.1.tar.xz"; local_filedir="${tmpdir}"; local_filename="moh_revival_v1.12_RC3.5.1.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="7c664538999252eeaf2b6d9949416480"
 	elif [ "${shortname}" == "ns" ]; then
-		remote_fileurl="http://linuxgsm.download/NaturalSelection/ns_dedicated_server_v32.tar.bz2"; local_filedir="${tmpdir}"; local_filename="ns_dedicated_server_v32.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="499cf63324b76925ada6baf5f2eacd67"
+		remote_fileurl="http://linuxgsm.download/NaturalSelection/ns_dedicated_server_v32.tar.xz"; local_filedir="${tmpdir}"; local_filename="ns_dedicated_server_v32.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="23ec3cadd93d8bb1c475bad5b9cce370"
 	elif [ "${shortname}" == "q2" ]; then
-		remote_fileurl="http://linuxgsm.download/Quake2/quake2-3.20-glibc-i386-full-linux2.0.tar.bz2"; local_filedir="${tmpdir}"; local_filename="quake2-3.20-glibc-i386-full-linux2.0.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="0b8c7e2d51f40b56b328c69e986e7c5f"
+		remote_fileurl="http://linuxgsm.download/Quake2/quake2-3.20-glibc-i386-full-linux2.0.tar.xz"; local_filedir="${tmpdir}"; local_filename="quake2-3.20-glibc-i386-full-linux2.0.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="2908164a32d4808bb720f2161f6b0c82"
 	elif [ "${shortname}" == "q3" ]; then
-		remote_fileurl="http://linuxgsm.download/Quake3/quake3-1.32c-x86-full-linux.tar.bz2"; local_filedir="${tmpdir}"; local_filename="quake3-1.32c-x86-full-linux.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="fd7258d827474f67663dda297bff4306"
+		remote_fileurl="http://linuxgsm.download/Quake3/quake3-1.32c-x86-full-linux.tar.xz"; local_filedir="${tmpdir}"; local_filename="quake3-1.32c-x86-full-linux.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="b0e26d8919fe9313fb9d8ded2360f3db"
 	elif [ "${shortname}" == "qw" ]; then
-		remote_fileurl="http://linuxgsm.download/QuakeWorld/nquake.server.linux.190506.full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="nquake.server.linux.190506.full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="74405ec030463c5e1175e776ab572d32"
+		remote_fileurl="http://linuxgsm.download/QuakeWorld/nquake.server.linux.190506.full.tar.xz"; local_filedir="${tmpdir}"; local_filename="nquake.server.linux.190506.full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="82055b7d973206c13a606db8ba288d03"
 	elif [ "${shortname}" == "rtcw" ]; then
-		remote_fileurl="http://linuxgsm.download/ReturnToCastleWolfenstein/iortcw-1.51c-x86_64-server-linux-20190507.tar.bz2"; local_filedir="${tmpdir}"; local_filename="iortcw-1.51c-x86_64-server-linux-20190507.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="6a3be9700372b228d1187422464e4212"
+		remote_fileurl="http://linuxgsm.download/ReturnToCastleWolfenstein/iortcw-1.51c-x86_64-server-linux-20190507.tar.xz"; local_filedir="${tmpdir}"; local_filename="iortcw-1.51c-x86_64-server-linux-20190507.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="df6ff664d37dd0d22787848bdb3cac5f"
 	elif [ "${shortname}" == "sfc" ]; then
-		remote_fileurl="http://linuxgsm.download/SourceFortsClassic/SFClassic-1.0-RC7-fix.tar.bz2"; local_filedir="${tmpdir}"; local_filename="SFClassic-1.0-RC7-fix.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="e0d4cfd298a8a356053f92b1fa7d1002"
+		remote_fileurl="http://linuxgsm.download/SourceFortsClassic/SFClassic-1.0-RC7-fix.tar.xz"; local_filedir="${tmpdir}"; local_filename="SFClassic-1.0-RC7-fix.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="70077137185700e28fe6bbb6021d12bc"
 	elif [ "${shortname}" == "sof2" ]; then
-		remote_fileurl="http://linuxgsm.download/SoldierOfFortune2/sof2gold-1.03.tar.bz2"; local_filedir="${tmpdir}"; local_filename="sof2gold-1.03.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="871b1dc0dafeeace65b198119e8fa200"
+		remote_fileurl="http://linuxgsm.download/SoldierOfFortune2/sof2gold-1.03.tar.xz"; local_filedir="${tmpdir}"; local_filename="sof2gold-1.03.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="201e23bab04207d00ce813d001c483d9"
 	elif [ "${shortname}" == "ts" ]; then
-		remote_fileurl="http://linuxgsm.download/TheSpecialists/ts-3-linux-final.tar.bz2"; local_filedir="${tmpdir}"; local_filename="ts-3-linux-final.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="38e8a8325339f85a7745117802f940b7"
+		remote_fileurl="http://linuxgsm.download/TheSpecialists/ts-3-linux-final.tar.xz"; local_filedir="${tmpdir}"; local_filename="ts-3-linux-final.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="3c66ecff6e3644f7ac88015732a0fb93"
 	elif [ "${shortname}" == "ut2k4" ]; then
-		remote_fileurl="http://linuxgsm.download/UnrealTournament2004/ut2004-server-3369-2-ultimate-linux.tar.bz2"; local_filedir="${tmpdir}"; local_filename="ut2004-server-3369-2-ultimate-linux.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="67c5e2cd9c2a4b04f163962ee41eff54"
+		remote_fileurl="http://linuxgsm.download/UnrealTournament2004/ut2004-server-3369-2-ultimate-linux.tar.xz"; local_filedir="${tmpdir}"; local_filename="ut2004-server-3369-2-ultimate-linux.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="8ebcb9b8f703905053d13a35c3af3e79"
 	elif [ "${shortname}" == "ut99" ]; then
-		remote_fileurl="http://linuxgsm.download/UnrealTournament99/ut99-server-451-ultimate-linux.tar.bz2"; local_filedir="${tmpdir}"; local_filename="ut99-server-451-ultimate-linux.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="49cb24d0550ff6ddeaba6007045c6edd"
+		remote_fileurl="http://linuxgsm.download/UnrealTournament99/ut99-server-451-ultimate-linux.tar.xz"; local_filedir="${tmpdir}"; local_filename="ut99-server-451-ultimate-linux.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="42c6839f8cb95907eeef71a1838aa1f7"
 	elif [ "${shortname}" == "ut" ]; then
 		remote_fileurl="http://linuxgsm.download/UnrealTournament/UnrealTournament-Server-XAN-3525360-Linux.zip"; local_filedir="${tmpdir}"; local_filename="UnrealTournament-Server-XAN-3525360-Linux.zip";  chmodx="noexecute" run="norun"; force="noforce"; md5="cad730ad6793ba6261f9a341ad7396eb"
 	elif [ "${shortname}" == "ut3" ]; then
-		remote_fileurl="http://linuxgsm.download/UnrealTournament3/UT3-linux-server-2.1.tar.bz2"; local_filedir="${tmpdir}"; local_filename="UT3-linux-server-2.1.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="2527437b46f1b47f20228d27d72395a6"
+		remote_fileurl="http://linuxgsm.download/UnrealTournament3/UT3-linux-server-2.1.tar.xz"; local_filedir="${tmpdir}"; local_filename="UT3-linux-server-2.1.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="6b92b083c7ab416399e2183a22fda1df"
 	elif [ "${shortname}" == "vs" ]; then
-		remote_fileurl="http://linuxgsm.download/VampireSlayer/vs_l-6.0_full.tar.bz2"; local_filedir="${tmpdir}"; local_filename="vs_l-6.0_full.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="38a79e44b98578bbdc5b15818493a066"
+		remote_fileurl="http://linuxgsm.download/VampireSlayer/vs_l-6.0_full.tar.xz"; local_filedir="${tmpdir}"; local_filename="vs_l-6.0_full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="b322f79e0abd31847493c52acf802667"
 	elif [ "${shortname}" == "wet" ]; then
 		remote_fileurl="http://linuxgsm.download/WolfensteinEnemyTerritory/enemy-territory.260b.tar.bz2"; local_filedir="${tmpdir}"; local_filename="enemy-territory.260b.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="f833f514bfcdd46b42c111f83350c5a7"
 	elif [ "${shortname}" == "samp" ]; then
 		remote_fileurl="https://files.sa-mp.com/samp037svr_R2-1.tar.gz"; local_filedir="${tmpdir}"; local_filename="samp037svr_R2-1.tar.gz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="93705e165550c97484678236749198a4"
 	elif [ "${shortname}" == "zmr" ]; then
-		remote_fileurl="http://linuxgsm.download/ZombieMasterReborn/zombie_master_reborn_b5_2.tar.bz2"; local_filedir="${tmpdir}"; local_filename="zombie_master_reborn_b5_2.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="d52ef2db376f5d21e3a4ceca85ec8761"
+		remote_fileurl="http://linuxgsm.download/ZombieMasterReborn/zombie_master_reborn_b5_2.tar.zx"; local_filedir="${tmpdir}"; local_filename="zombie_master_reborn_b5_2.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="4b9b9832e863d03981a40c26065792a6"
 	fi
 	fn_fetch_file "${remote_fileurl}" "${local_filedir}" "${local_filename}" "${chmodx}" "${run}" "${forcedl}" "${md5}"
 	fn_dl_extract "${local_filedir}" "${local_filename}" "${serverfiles}"

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -52,7 +52,7 @@ fn_install_server_files(){
 	elif [ "${shortname}" == "ut99" ]; then
 		remote_fileurl="http://linuxgsm.download/UnrealTournament99/ut99-server-451-ultimate-linux.tar.xz"; local_filedir="${tmpdir}"; local_filename="ut99-server-451-ultimate-linux.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="42c6839f8cb95907eeef71a1838aa1f7"
 	elif [ "${shortname}" == "ut" ]; then
-		remote_fileurl="http://linuxgsm.download/UnrealTournament/UnrealTournament-Server-XAN-3525360-Linux.tar.xz"; local_filedir="${tmpdir}"; local_filename="UnrealTournament-Server-XAN-3525360-Linux.zip";  chmodx="noexecute" run="norun"; force="noforce"; md5="41dd92015713a78211eaccf503b72393"
+		remote_fileurl="http://linuxgsm.download/UnrealTournament/UnrealTournament-Server-XAN-3525360-Linux.tar.xz"; local_filedir="${tmpdir}"; local_filename="UnrealTournament-Server-XAN-3525360-Linux.tar.xz";  chmodx="noexecute" run="norun"; force="noforce"; md5="8876cca61e3f83ea08db25208bde6ac6"
 	elif [ "${shortname}" == "ut3" ]; then
 		remote_fileurl="http://linuxgsm.download/UnrealTournament3/UT3-linux-server-2.1.tar.xz"; local_filedir="${tmpdir}"; local_filename="UT3-linux-server-2.1.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="6b92b083c7ab416399e2183a22fda1df"
 	elif [ "${shortname}" == "vs" ]; then

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -58,7 +58,7 @@ fn_install_server_files(){
 	elif [ "${shortname}" == "vs" ]; then
 		remote_fileurl="http://linuxgsm.download/VampireSlayer/vs_l-6.0_full.tar.xz"; local_filedir="${tmpdir}"; local_filename="vs_l-6.0_full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="b322f79e0abd31847493c52acf802667"
 	elif [ "${shortname}" == "wet" ]; then
-		remote_fileurl="http://linuxgsm.download/WolfensteinEnemyTerritory/enemy-territory.260b.tar.bz2"; local_filedir="${tmpdir}"; local_filename="enemy-territory.260b.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="f833f514bfcdd46b42c111f83350c5a7"
+		remote_fileurl="http://linuxgsm.download/WolfensteinEnemyTerritory/enemy-territory.260b.tar.xz"; local_filedir="${tmpdir}"; local_filename="enemy-territory.260b.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="581a333cc7eacda2f56d5a00fe11eafa"
 	elif [ "${shortname}" == "samp" ]; then
 		remote_fileurl="https://files.sa-mp.com/samp037svr_R2-1.tar.gz"; local_filedir="${tmpdir}"; local_filename="samp037svr_R2-1.tar.gz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="93705e165550c97484678236749198a4"
 	elif [ "${shortname}" == "zmr" ]; then

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -62,7 +62,7 @@ fn_install_server_files(){
 	elif [ "${shortname}" == "samp" ]; then
 		remote_fileurl="https://files.sa-mp.com/samp037svr_R2-1.tar.gz"; local_filedir="${tmpdir}"; local_filename="samp037svr_R2-1.tar.gz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="93705e165550c97484678236749198a4"
 	elif [ "${shortname}" == "zmr" ]; then
-		remote_fileurl="http://linuxgsm.download/ZombieMasterReborn/zombie_master_reborn_b5_2.tar.zx"; local_filedir="${tmpdir}"; local_filename="zombie_master_reborn_b5_2.tar.bz2"; chmodx="nochmodx" run="norun"; force="noforce"; md5="4b9b9832e863d03981a40c26065792a6"
+		remote_fileurl="http://linuxgsm.download/ZombieMasterReborn/zombie_master_reborn_b5_2.tar.xz"; local_filedir="${tmpdir}"; local_filename="zombie_master_reborn_b5_2.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="4b9b9832e863d03981a40c26065792a6"
 	fi
 	fn_fetch_file "${remote_fileurl}" "${local_filedir}" "${local_filename}" "${chmodx}" "${run}" "${forcedl}" "${md5}"
 	fn_dl_extract "${local_filedir}" "${local_filename}" "${serverfiles}"

--- a/lgsm/functions/install_server_files.sh
+++ b/lgsm/functions/install_server_files.sh
@@ -10,7 +10,7 @@ local function_selfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 fn_install_server_files(){
 	if [ "${shortname}" == "ahl" ]; then
-		remote_fileurl="http://linuxgsm.download/ActionHalfLife/action_halflife-1.0.tar.zx"; local_filedir="${tmpdir}"; local_filename="action_halflife-1.0.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="61d7b79fd714888b6d65944fdaafa94a"
+		remote_fileurl="http://linuxgsm.download/ActionHalfLife/action_halflife-1.0.tar.xz"; local_filedir="${tmpdir}"; local_filename="action_halflife-1.0.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="61d7b79fd714888b6d65944fdaafa94a"
 	elif [ "${shortname}" == "bf1942" ]; then
 		remote_fileurl="http://linuxgsm.download/BattleField1942/bf1942_lnxded-1.61-hacked-to-1.612.full.tar.xz"; local_filedir="${tmpdir}"; local_filename="bf1942_lnxded-1.61-hacked-to-1.612.full.tar.xz"; chmodx="nochmodx" run="norun"; force="noforce"; md5="4223bf4ed85f5162c24b2cba51249b9e"
 	elif [ "${shortname}" == "bb" ]; then


### PR DESCRIPTION
# Description

Servers that don't use steamcmd have had their archives converted to use .tar.xz as it saw a significant reduction in file size and speed up decompression.

Fixes #2816 

## Type of change

* [ ] Bug fix (change which fixes an issue).
* [x] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
