### PR TITLE
fix(update): Minecraft Bedrock issue causing update to not grab the version from logs

### DIFF
--- a/lgsm/functions/update_minecraft_bedrock.sh
+++ b/lgsm/functions/update_minecraft_bedrock.sh
@@ -33,7 +33,7 @@ fn_update_minecraft_localbuild(){
 	fn_print_dots "Checking local build: ${remotelocation}"
 	# Uses log file to gather info.
 	# Log is generated and cleared on startup but filled on shutdown.
-	localbuild=$(grep Version "$(ls -tr "${consolelogdir}"/* 2>/dev/null)" | tail -1 | sed 's/.*Version //')
+	localbuild=$(grep Version "${consolelogdir}"/* 2>/dev/null | tail -1 | sed 's/.*Version //')
 	if [ -z "${localbuild}" ]; then
 		fn_print_error "Checking local build: ${remotelocation}"
 		fn_print_error_nl "Checking local build: ${remotelocation}: no log files containing version info"


### PR DESCRIPTION
# Description

Summary:
Removed unnecessary ls -tr and shell expansion from the variable as it was not setting the localbuild variable properly. Without this set, the update command would fail out.
```
[mcbserver@linuxgsm ~]$ ./mcbserver update
[ .... ] Update mcbserver: Checking local build: minecraft.net++++++ tail -1
++++++ sed 's/.*Version //'
+++++++ ls -tr /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-05-19:05:59.log /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-06-03:32:32.log /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-06-08:30:01.log /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-06-10:52:34.log /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-07-08:31:07.log /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-07-22:10:08.log /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-08-08:30:02.log /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-08-10:06:45.log /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-09-08:30:01.log /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-09-10:06:07.log /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-09-10:14:05.log /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-10-08:30:01.log /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-10-10:32:04.log /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-10-10:45:59.log /opt/gameservers/mcbserver/log/console/mcbserver-console.log
++++++ grep Version '/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-05-19:05:59.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-06-03:32:32.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-06-08:30:01.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-06-10:52:34.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-07-08:31:07.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-07-22:10:08.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-08-08:30:02.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-08-10:06:45.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-09-08:30:01.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-09-10:06:07.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-09-10:14:05.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-10-08:30:01.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-10-10:32:04.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-10-10:45:59.log
/opt/gameservers/mcbserver/log/console/mcbserver-console.log'
grep: /opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-05-19:05:59.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-06-03:32:32.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-06-08:30:01.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-06-10:52:34.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-07-08:31:07.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-07-22:10:08.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-08-08:30:02.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-08-10:06:45.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-09-08:30:01.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-09-10:06:07.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-09-10:14:05.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-10-08:30:01.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-10-10:32:04.log
/opt/gameservers/mcbserver/log/console/mcbserver-console-2020-05-10-10:45:59.log
/opt/gameservers/mcbserver/log/console/mcbserver-console.log: No such file or directory
+++++ localbuild=
+++++ set +x
```
Fixes #2877 

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.
