### PR TITLE
feat(avorion): remove avgalaxy variable and replace with selfname

### DIFF
--- a/lgsm/config-default/config-lgsm/avserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/avserver/_default.cfg
@@ -11,14 +11,13 @@
 port="27000"
 # https://steamidfinder.com
 adminsteamid=""
-avgalaxy="avgalaxy"
 
 ## Server Start Command | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
 fn_parms(){
 if [ ! -z "${adminsteamid}" ]; then
 	admincmd="--admin ${adminsteamid}"
 fi
-parms="--galaxy-name ${avgalaxy} --ip ${ip} --datapath ${avdatapath} ${admincmd}"
+parms="--galaxy-name ${selfname} --ip ${ip} --datapath ${avdatapath} ${admincmd}"
 }
 
 #### LinuxGSM Settings ####
@@ -146,7 +145,7 @@ glibc="2.15"
 
 ## Game Server Directories
 avdatapath="${serverfiles}/galaxy"
-avgalaxypath="${avdatapath}/${avgalaxy}"
+avgalaxypath="${avdatapath}/${selfname}"
 systemdir="${serverfiles}"
 executabledir="${systemdir}"
 executable="./server.sh"


### PR DESCRIPTION
# Description

removed avgalaxy variable in favour of using selfname for galaxy directory. This will also help with multi instance servers

Fixes #2885

## Type of change

* [ ] Bug fix (a change which fixes an issue).
* [x] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [ ] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
