### PR TITLE
fix: query_gamedig.sh tuning for correct player count

### DIFF
--- a/lgsm/functions/query_gamedig.sh
+++ b/lgsm/functions/query_gamedig.sh
@@ -22,7 +22,6 @@ if [ "$(command -v gamedig 2>/dev/null)" ]&&[ "$(command -v jq 2>/dev/null)" ]; 
 			gamedigcmd=$(echo -e "gamedig --type \"${querytype}\" --host \"${ip}\" --port \"${queryport}\"|jq")
 			gamedigraw=$(gamedig --type "${querytype}" --host "${ip}" --port "${queryport}")
 			querystatus=$(echo "${gamedigraw}" | jq '.error|length')
-
 		fi
 
 		# server name.

--- a/lgsm/functions/query_gamedig.sh
+++ b/lgsm/functions/query_gamedig.sh
@@ -32,11 +32,15 @@ if [ "$(command -v gamedig 2>/dev/null)" ]&&[ "$(command -v jq 2>/dev/null)" ]; 
 		fi
 
 		# numplayers.
-		gdplayers=$(echo "${gamedigraw}" | jq -re '.raw.vanilla.raw.players.online')
+		if [ "${querytype}" == "minecraft" ]; then
+				gdplayers=$(echo "${gamedigraw}" | jq -re '.players | length-1')
+			else
+				gdplayers=$(echo "${gamedigraw}" | jq -re '.players | length')
+		fi
 		if [ "${gdplayers}" == "null" ]; then
 			unset gdplayers
-		elif [ "${gdplayers}" == "[]" ]; then
-			gdplayers=0
+		elif [ "${gdplayers}" == "[]" ] || [ "${gdplayers}" == "-1" ]; then
+		 	gdplayers=0
 		fi
 
 		# maxplayers.
@@ -60,7 +64,7 @@ if [ "$(command -v gamedig 2>/dev/null)" ]&&[ "$(command -v jq 2>/dev/null)" ]; 
 		fi
 
 		# numbots.
-		gdbots=$(echo "${gamedigraw}" | jq -re '.raw.numbots')
+		gdbots=$(echo "${gamedigraw}" | jq -re '.bots | length')
 		if [ "${gdbots}" == "null" ]||[ "${gdbots}" == "0" ]; then
 			unset gdbots
 		fi

--- a/lgsm/functions/query_gamedig.sh
+++ b/lgsm/functions/query_gamedig.sh
@@ -33,14 +33,14 @@ if [ "$(command -v gamedig 2>/dev/null)" ]&&[ "$(command -v jq 2>/dev/null)" ]; 
 
 		# numplayers.
 		if [ "${querytype}" == "minecraft" ]; then
-				gdplayers=$(echo "${gamedigraw}" | jq -re '.players | length-1')
-			else
-				gdplayers=$(echo "${gamedigraw}" | jq -re '.players | length')
+			gdplayers=$(echo "${gamedigraw}" | jq -re '.players | length-1')
+		else
+			gdplayers=$(echo "${gamedigraw}" | jq -re '.players | length')
 		fi
 		if [ "${gdplayers}" == "null" ]; then
 			unset gdplayers
 		elif [ "${gdplayers}" == "[]" ] || [ "${gdplayers}" == "-1" ]; then
-		 	gdplayers=0
+			gdplayers=0
 		fi
 
 		# maxplayers.


### PR DESCRIPTION
# Description

This fix reverts a small change that was made and re-writes it to count the number of objects in the "players" endpoint of the gamedig output.

Fixes #2912 

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
