### PR TITLE
fix(starbound): Details command fix

### DIFF
--- a/lgsm/functions/info_messages.sh
+++ b/lgsm/functions/info_messages.sh
@@ -1462,7 +1462,7 @@ fn_info_message_select_engine(){
 		fn_info_message_sof2
 	elif [ "${shortname}" == "sol" ]; then
 		fn_info_message_soldat
-	elif [ "${shortname}" == "st" ]; then
+	elif [ "${shortname}" == "sb" ]; then
 		fn_info_message_starbound
 	elif [ "${shortname}" == "sbots" ]; then
 		fn_info_message_sbots


### PR DESCRIPTION
# Description

info_messages had a typo for the shortname for StarBound causing the details command to error out when trying to output useful network command.

Fixes #2919

## Type of change

* [X] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [X] This pull request links to an issue.
* [X] This pull request uses the `develop` branch as its base.
* [X] This pull request Subject follows the Conventional Commits standard.
* [X] This code follows the style guidelines of this project.
* [X] I have performed a self-review of my code.
* [X] I have checked that this code is commented where required.
* [X] I have provided a detailed with enough description of this PR.
* [X] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
