### PR TITLE
fix(debian 11): change name of lib32gcc1 to lib32gcc-s1 for debian 11

### DIFF
--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -184,8 +184,15 @@ if [ "${javacheck}" == "1" ]; then
 		fi
 		# Define required dependencies for SteamCMD.
 		if [ "${appid}" ]; then
-			if [ "${deptocheck}" ==  "glibc.i686" ]||[ "${deptocheck}" ==  "libstdc++64.i686" ]||[ "${deptocheck}" ==  "lib32gcc1" ]||[ "${deptocheck}" ==  "lib32stdc++6" ]; then
-				steamcmdfail=1
+			# lib32gcc1 is now called lib32gcc-s1 in debian 11
+			if [ "${distroid}" == "debian" ]&&[ "${distroversion}" == "11" ]; then
+				if [ "${deptocheck}" ==  "glibc.i686" ]||[ "${deptocheck}" ==  "libstdc++64.i686" ]||[ "${deptocheck}" ==  "lib32gcc-s1" ]||[ "${deptocheck}" ==  "lib32stdc++6" ]; then
+					steamcmdfail=1
+				fi
+			else
+				if [ "${deptocheck}" ==  "glibc.i686" ]||[ "${deptocheck}" ==  "libstdc++64.i686" ]||[ "${deptocheck}" ==  "lib32gcc1" ]||[ "${deptocheck}" ==  "lib32stdc++6" ]; then
+					steamcmdfail=1
+				fi
 			fi
 		fi
 	fi
@@ -342,7 +349,12 @@ fn_deps_build_debian(){
 	# All servers except ts3, mumble, GTA and minecraft servers require lib32stdc++6 and lib32gcc1.
 	if [ "${shortname}" != "ts3" ]&&[ "${shortname}" != "mumble" ]&&[ "${shortname}" != "mc" ]&&[ "${engine}" != "renderware" ]; then
 		if [ "${arch}" == "x86_64" ]; then
-			array_deps_required+=( lib32gcc1 lib32stdc++6 )
+			# lib32gcc1 is now called lib32gcc-s1 in debian 11
+			if [ "${distroid}" == "debian" ]&&[ "${distroversion}" == "11" ]; then
+				array_deps_required+=( lib32gcc-s1 lib32stdc++6 )
+			else
+				array_deps_required+=( lib32gcc1 lib32stdc++6 )
+			fi
 		else
 			array_deps_required+=( lib32stdc++6 )
 		fi


### PR DESCRIPTION
# Description

Debian 11 has changed the name of lib32gcc1 to lib32gcc-s1.

I am not updating the website until Debian 11 is released. However, I have added the code ready for the next release of debian.

Fixes #2905

## Type of change

* [ ] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [x] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
