### PR TITLE
feat(rustserver): add support for Rust + app

### DIFF
--- a/lgsm/config-default/config-lgsm/rustserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rustserver/_default.cfg
@@ -13,6 +13,7 @@
 ip="0.0.0.0"
 port="28015"
 rconport="28016"
+appport=28082
 rconpassword="CHANGE_ME"
 rconweb="1" # Value is: 1 for Facepunch's web panel; 0 for RCON tools like Rusty or Rustadmin
 servername="Rust"
@@ -42,7 +43,7 @@ else
 	# Keep randomness of the number if not set
 	conditionalsalt=""
 fi
-parms="-batchmode +server.ip ${ip} +server.port ${port} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${selfname}\" ${conditionalseed} ${conditionalsalt} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile \"${gamelogdate}\""
+parms="-batchmode +server.ip ${ip} +server.port ${port} +app.port ${appport} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${selfname}\" ${conditionalseed} ${conditionalsalt} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile \"${gamelogdate}\""
 }
 
 #### LinuxGSM Settings ####


### PR DESCRIPTION
# Description

Adds the Rust+ App Port which for Linux appears to be required via command-line.

fixes #2914 

## Type of change

* [ ] Bug fix (a change which fixes an issue).
* [x] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).