### PR TITLE
fix: awk now properly grabs the server pid when spaces are present in the session name

### DIFF
--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -9,7 +9,7 @@ functionselfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 ### Game Server pid
 if [ "${status}" == "1" ]; then
-	gameserverpid=$(tmux list-sessions -F "#{session_name} #{pane_pid}" | grep "^${sessionname} " | awk '{print $2}')
+	gameserverpid=$(tmux list-sessions -F "#{session_name} #{pane_pid}" | grep "^${sessionname} " | awk '{print $NF}')
 fi
 ### Distro information
 


### PR DESCRIPTION
awk now properly grabs the server pid when spaces are present in the session name

# Description

awk now uses the varibale $NF to print the last word on the line instead of the second word on the line

Fixes #2996

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
