### PR TITLE
fix(sdtdserver): config parsing for the port

### DIFF
--- a/lgsm/functions/info_config.sh
+++ b/lgsm/functions/info_config.sh
@@ -1231,7 +1231,7 @@ fn_info_config_sdtd(){
 	else
 		servername=$(grep "ServerName" "${servercfgfullpath}" | sed 's/^.*value="//' | cut -f1 -d"\"")
 		serverpassword=$(grep "ServerPassword" "${servercfgfullpath}" | sed 's/^.*value="//' | cut -f1 -d"\"")
-		port=$(grep "ServerPort" "${servercfgfullpath}" | tr -cd '[:digit:]')
+		port=$(grep "ServerPort" "${servercfgfullpath}" | egrep -o 'value="[0-9]+"' | tr -cd '[:digit:]')
 		queryport=${port:-"0"}
 
 		webadminenabled=$(grep "ControlPanelEnabled" "${servercfgfullpath}" | sed 's/^.*value="//' | cut -f1 -d"\"")


### PR DESCRIPTION
# Description

With the current config parting for the sdtd port it can happen, that all numbers in the same line can be parsed as the port.

Fixes #3006

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [ ] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
