### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/linuxgsm/fb7101d3-9ead-43c3-b88a-7382f8f102af/26e5f8ef-eff3-411f-9243-f1e50d22601e/_apis/work/boardbadge/1acffe2e-0056-400a-b545-9b343c37939e)](https://dev.azure.com/linuxgsm/fb7101d3-9ead-43c3-b88a-7382f8f102af/_boards/board/t/26e5f8ef-eff3-411f-9243-f1e50d22601e/Microsoft.RequirementCategory)
 <h1 align="center">
   <br>
   <a href="https://linuxgsm.com"><img src="https://i.imgur.com/Eoh1jsi.jpg" alt="LinuxGSM"></a>


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/linuxgsm/fb7101d3-9ead-43c3-b88a-7382f8f102af/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.