### PR TITLE
fix(mcserver): Support installing previous minecraft versions via branch

### DIFF
--- a/lgsm/functions/update_minecraft.sh
+++ b/lgsm/functions/update_minecraft.sh
@@ -10,7 +10,7 @@ fn_update_minecraft_dl(){
 	if [ "${branch}" == "release" ]; then
 		latestmcreleaselink=$(curl -s "https://launchermeta.${remotelocation}/mc/game/version_manifest.json" | jq -r '.latest.release as $latest | .versions[] | select(.id == $latest) | .url')
 	else
-		latestmcreleaselink=$(curl -s "https://launchermeta.${remotelocation}/mc/game/version_manifest.json" | jq -r '.versions[0].url')
+		latestmcreleaselink=$(curl -s "https://launchermeta.${remotelocation}/mc/game/version_manifest.json" | jq -r '.versions | .[] | select(.id=="${branch}") | .url')
 	fi
 
 	latestmcbuildurl=$(curl -s "${latestmcreleaselink}" | jq -r '.downloads.server.url')
@@ -80,7 +80,7 @@ fn_update_minecraft_remotebuild(){
 	if [ "${branch}" == "release" ]; then
 		remotebuild=$(curl -s "https://launchermeta.${remotelocation}/mc/game/version_manifest.json" | jq -r '.latest.release')
 	else
-		remotebuild=$(curl -s "https://launchermeta.${remotelocation}/mc/game/version_manifest.json" | jq -r '.versions[0].id')
+		remotebuild=$(curl -s "https://launchermeta.${remotelocation}/mc/game/version_manifest.json" | jq -r '.versions | .[] | select(.id=="${branch}") | .id')
 	fi
 
 	if [ "${firstcommandname}" != "INSTALL" ]; then


### PR DESCRIPTION
# Description

When the branch for minecraft is set, This should allow lgsm to download a previous version. 

I haven't actually tested this in LGSM yet, I only tested the updated jq command manually:
```
curl -s "https://launchermeta.mojang.com/mc/game/version_manifest.json" | jq -r '.versions | .[] | select(.id=="1.15") | .url'
```

Previously it would always grab the latest MC version, even if the branch was set. 

The branch [defaults](https://github.com/GameServerManagers/LinuxGSM/blob/master/lgsm/config-default/config-lgsm/mcserver/_default.cfg#L20) to "release", so as long as no one has changed that this shouldn't impact anyone's current configs 



Fixes #[issue]

## Type of change

* [ ] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
