### PR TITLE
fix(update): resolve broken minecraft updater since v1.16.3

### DIFF
--- a/lgsm/functions/update_factorio.sh
+++ b/lgsm/functions/update_factorio.sh
@@ -112,6 +112,7 @@ fn_update_factorio_compare(){
 			command_start.sh
 			fn_firstcommand_reset
 		fi
+		unset exitbypass
 		date +%s > "${lockdir}/lastupdate.lock"
 		alert="update"
 		alert.sh

--- a/lgsm/functions/update_minecraft.sh
+++ b/lgsm/functions/update_minecraft.sh
@@ -35,7 +35,7 @@ fn_update_minecraft_localbuild(){
 	# Gets local build info.
 	fn_print_dots "Checking local build: ${remotelocation}"
 	# Uses log file to gather info.
-	localbuild=$(grep -i version "${consolelogdir}"/* 2>/dev/null | tail -1 | sed 's/.*[Vv]ersion //';'s/\r//g')
+	localbuild=$(grep -i version "${consolelogdir}"/* | tail -1 | sed 's/.*[Vv]ersion //' | sed 's/\r//g' 2>/dev/null)
 	if [ -z "${localbuild}" ]; then
 		fn_print_error "Checking local build: ${remotelocation}"
 		fn_print_error_nl "Checking local build: ${remotelocation}: no log files containing version info"
@@ -49,7 +49,7 @@ fn_update_minecraft_localbuild(){
 		command_start.sh
 		fn_firstcommand_reset
 		totalseconds=0
-		localbuild=$(grep -i version "${consolelogdir}"/* 2>/dev/null | tail -1 | sed 's/.*[Vv]ersion //';'s/\r//g')
+		localbuild=$(grep -i version "${consolelogdir}"/* | tail -1 | sed 's/.*[Vv]ersion //' | sed 's/\r//g' 2>/dev/null)
 		while [ -z "${localbuild}" ]; do
 			sleep 1
 			fn_print_info "Checking local build: ${remotelocation}: waiting for log file: ${totalseconds}"
@@ -58,7 +58,7 @@ fn_update_minecraft_localbuild(){
 				fn_script_log_info "Waiting for log file to generate"
 			fi
 
-			localbuild=$(grep -i version "${consolelogdir}"/* 2>/dev/null | tail -1 | sed 's/.*[Vv]ersion //';'s/\r//g')
+			localbuild=$(grep -i version "${consolelogdir}"/* | tail -1 | sed 's/.*[Vv]ersion //' | sed 's/\r//g' 2>/dev/null)
 			if [ "${totalseconds}" -gt "120" ]; then
 				localbuild="0"
 				fn_print_error "Checking local build: ${remotelocation}: waiting for log file"
@@ -145,6 +145,7 @@ fn_update_minecraft_compare(){
 			command_start.sh
 			fn_firstcommand_reset
 		fi
+		unset exitbypass
 		date +%s > "${lockdir}/lastupdate.lock"
 		alert="update"
 		alert.sh

--- a/lgsm/functions/update_minecraft.sh
+++ b/lgsm/functions/update_minecraft.sh
@@ -35,7 +35,7 @@ fn_update_minecraft_localbuild(){
 	# Gets local build info.
 	fn_print_dots "Checking local build: ${remotelocation}"
 	# Uses log file to gather info.
-	localbuild=$(grep Version "${consolelogdir}"/* 2>/dev/null | tail -1 | sed 's/.*Version //')
+	localbuild=$(grep -i version "${consolelogdir}"/* 2>/dev/null | tail -1 | sed 's/.*[Vv]ersion //';'s/\r//g')
 	if [ -z "${localbuild}" ]; then
 		fn_print_error "Checking local build: ${remotelocation}"
 		fn_print_error_nl "Checking local build: ${remotelocation}: no log files containing version info"
@@ -49,7 +49,7 @@ fn_update_minecraft_localbuild(){
 		command_start.sh
 		fn_firstcommand_reset
 		totalseconds=0
-		localbuild=$(grep Version "${consolelogdir}"/* 2>/dev/null | tail -1 | sed 's/.*Version //')
+		localbuild=$(grep -i version "${consolelogdir}"/* 2>/dev/null | tail -1 | sed 's/.*[Vv]ersion //';'s/\r//g')
 		while [ -z "${localbuild}" ]; do
 			sleep 1
 			fn_print_info "Checking local build: ${remotelocation}: waiting for log file: ${totalseconds}"
@@ -58,7 +58,7 @@ fn_update_minecraft_localbuild(){
 				fn_script_log_info "Waiting for log file to generate"
 			fi
 
-			localbuild=$(grep Version "$(ls -tr "${consolelogdir}"/* 2>/dev/null)" | tail -1 | sed 's/.*Version //')
+			localbuild=$(grep -i version "${consolelogdir}"/* 2>/dev/null | tail -1 | sed 's/.*[Vv]ersion //';'s/\r//g')
 			if [ "${totalseconds}" -gt "120" ]; then
 				localbuild="0"
 				fn_print_error "Checking local build: ${remotelocation}: waiting for log file"

--- a/lgsm/functions/update_minecraft_bedrock.sh
+++ b/lgsm/functions/update_minecraft_bedrock.sh
@@ -139,6 +139,7 @@ fn_update_minecraft_compare(){
 			command_start.sh
 			fn_firstcommand_reset
 		fi
+		unset exitbypass
 		date +%s > "${lockdir}/lastupdate.lock"
 		alert="update"
 		alert.sh

--- a/lgsm/functions/update_mta.sh
+++ b/lgsm/functions/update_mta.sh
@@ -168,6 +168,7 @@ fn_update_mta_compare(){
 			command_start.sh
 			fn_firstcommand_reset
 		fi
+		unset exitbypass
 		date +%s > "${lockdir}/lastupdate.lock"
 		alert="update"
 		alert.sh

--- a/lgsm/functions/update_mumble.sh
+++ b/lgsm/functions/update_mumble.sh
@@ -104,6 +104,7 @@ fn_update_mumble_compare(){
 			command_start.sh
 			fn_firstcommand_reset
 		fi
+		unset exitbypass
 		date +%s > "${lockdir}/lastupdate.lock"
 		alert="update"
 		alert.sh

--- a/lgsm/functions/update_steamcmd.sh
+++ b/lgsm/functions/update_steamcmd.sh
@@ -113,6 +113,7 @@ fn_update_steamcmd_compare(){
 			command_start.sh
 			fn_firstcommand_reset
 		fi
+		unset exitbypass
 		date +%s > "${lockdir}/lastupdate.lock"
 		alert="update"
 		alert.sh

--- a/lgsm/functions/update_ts3.sh
+++ b/lgsm/functions/update_ts3.sh
@@ -166,6 +166,7 @@ fn_update_ts3_compare(){
 			command_start.sh
 			fn_firstcommand_reset
 		fi
+		unset exitbypass
 		date +%s > "${lockdir}/lastupdate.lock"
 		alert="update"
 		alert.sh


### PR DESCRIPTION
# Description

Resolve Minecraft updater no longer working after recent update to Minecraft

Mojang altered the console output to use `\r` Windows file ending. Breaking the version comparison


Fixes #3066

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
