### PR TITLE
fix(deps): change ubuntu 20.10 to use lib32gcc-s1

### DIFF
--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -185,7 +185,7 @@ if [ "${javacheck}" == "1" ]; then
 		# Define required dependencies for SteamCMD.
 		if [ "${appid}" ]; then
 			# lib32gcc1 is now called lib32gcc-s1 in debian 11
-			if [ "${distroid}" == "debian" ]&&[ "${distroversion}" == "11" ]; then
+			if { [ "${distroid}" == "debian" ]&&[ "${distroversion}" == "11" ]; }||{ [ "${distroid}" == "ubuntu" ]&&[ "${distroversion}" == "20.10" ]; }; then
 				if [ "${deptocheck}" ==  "glibc.i686" ]||[ "${deptocheck}" ==  "libstdc++64.i686" ]||[ "${deptocheck}" ==  "lib32gcc-s1" ]||[ "${deptocheck}" ==  "lib32stdc++6" ]; then
 					steamcmdfail=1
 				fi
@@ -349,7 +349,7 @@ fn_deps_build_debian(){
 	if [ "${shortname}" != "ts3" ]&&[ "${shortname}" != "mumble" ]&&[ "${shortname}" != "mc" ]&&[ "${engine}" != "renderware" ]; then
 		if [ "${arch}" == "x86_64" ]; then
 			# lib32gcc1 is now called lib32gcc-s1 in debian 11
-			if [ "${distroid}" == "debian" ]&&[ "${distroversion}" == "11" ]; then
+			if { [ "${distroid}" == "debian" ]&&[ "${distroversion}" == "11" ]; }|| { [ "${distroid}" == "ubuntu" ]&&[ "${distroversion}" == "20.10" ]; }; then
 				array_deps_required+=( lib32gcc-s1 lib32stdc++6 )
 			else
 				array_deps_required+=( lib32gcc1 lib32stdc++6 )


### PR DESCRIPTION
# Description

changes the dependency for ubuntu 20.10 to lib32gcc-s1

Fixes #3093 

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [ ] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [ ] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
