### PR TITLE
fix(bf1942): servername parsing

### DIFF
--- a/lgsm/functions/info_config.sh
+++ b/lgsm/functions/info_config.sh
@@ -188,7 +188,7 @@ fn_info_config_bf1942(){
 		queryport="${zero}"
 	else
 
-		servername=$(grep "game.serverName" "${servercfgfullpath}" | sed -e 's/^[ \t]*//g' -e '/^--/d' -e 's/game.serverName //g' | tr -d '=\";,:' | xargs)
+		servername=$(grep -E "^game.serverName " "${servercfgfullpath}" | sed -e 's/^[ \t]*//g' -e '/^--/d' -e 's/game.serverName //g' | tr -d '=\";,:' | xargs)
 		serverpassword=$(grep "game.serverPassword" "${servercfgfullpath}" | sed -e 's/^ *//g' -e '/^--/d' -e 's/game.serverPassword//g' | tr -d '=\";,:' | xargs)
 		maxplayers=$(grep "game.serverMaxPlayers" "${servercfgfullpath}" | grep -v "\--" | tr -cd '[:digit:]')
 		port=$(grep "game.serverPort" "${servercfgfullpath}" | grep -v "\--" | tr -cd '[:digit:]')


### PR DESCRIPTION
# Description

Fixes the servername parsing with a more strict parsing

Fixes #3095 

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
