### PR TITLE
Fix Stop Command when console has pending input

### DIFF
--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -43,7 +43,7 @@ fn_stop_graceful_cmd(){
 	fn_print_dots "Graceful: sending \"${1}\""
 	fn_script_log_info "Graceful: sending \"${1}\""
 	# Sends specific stop command.
-	tmux send -t "${sessionname}" "${1}" ENTER > /dev/null 2>&1
+	tmux send -t "${sessionname}" ENTER "${1}" ENTER > /dev/null 2>&1
 	# Waits up to ${seconds} seconds giving the server time to shutdown gracefully.
 	for ((seconds=1; seconds<=${2}; seconds++)); do
 		check_status.sh


### PR DESCRIPTION

# Description

When executing the stop command whilst something is still typed in the server session (enter was not pressed), the stop command will time out and fail, requiring manual intervention.

## Type of change

This pull request simply "flushes" the command buffer by pressing enter. This may cause unintended behavior, such as a typed command getting implicitly executed, but the command will only have an impact on the game state if its persistent between restarts.

Properly execute quit when the session was improperly detached with something typed on the command line.
For example, someone types a command into the server console, then detaches. The stop command will wait, fail and need manual intervention.

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [ ] This pull request uses the `develop` branch as its base.
* [ ] This pull request Subject follows the Conventional Commits standard.
* [ ] This code follows the style guidelines of this project.
* [ ] I have performed a self-review of my code.
* [ ] I have checked that this code is commented where required.
* [ ] I have provided a detailed with enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
