### PR TITLE
fix(stop) stop will clear tmux text before entering stop command

### DIFF
--- a/lgsm/functions/command_stop.sh
+++ b/lgsm/functions/command_stop.sh
@@ -43,7 +43,7 @@ fn_stop_graceful_cmd(){
 	fn_print_dots "Graceful: sending \"${1}\""
 	fn_script_log_info "Graceful: sending \"${1}\""
 	# Sends specific stop command.
-	tmux send -t "${sessionname}" "${1}" ENTER > /dev/null 2>&1
+	tmux send -t "${sessionname}" ENTER "${1}" ENTER > /dev/null 2>&1
 	# Waits up to ${seconds} seconds giving the server time to shutdown gracefully.
 	for ((seconds=1; seconds<=${2}; seconds++)); do
 		check_status.sh


### PR DESCRIPTION
# Description

When executing the stop command whilst something is still typed in the server session (enter was not pressed), the stop command will time out and fail, requiring manual intervention.

Fixes #3141 

## Type of change

* [x] Fix Stop Command when a user has typed something into the console without pressing enter.

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Caveats
This fix is rather crude, I have tried to clear the command that was typed in without executing it (which could cause unwanted behavior). But I was ultimately unsuccessful and this fixes the actual issue just fine (also lots of server operations are lost on stop anyways).

Also pardon my old (now "drafted") PR I made. I'm still figuring out how GitHub works.