### PR TITLE
fix(steamcmd): add dependency SDL 32bit for debian and ubuntu

### DIFF
--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -364,7 +364,7 @@ fn_deps_build_debian(){
 		if [ "${distroversion}" == "14.04" ]||[ "${distroid}" == "debian" ]&& ! grep -qE "^deb .*non-free" /etc/apt/sources.list; then
 			:
 		else
-			array_deps_required+=( steamcmd )
+			array_deps_required+=( steamcmd libsdl2-2.0-0:i386 )
 		fi
 	fi
 


### PR DESCRIPTION
# Description

Adds the dependency for debian and ubuntu for 32bit to fix the "error"
Message:
`Failed to init SDL priority manager: SDL not found`

Fixes #2701

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
