### PR TITLE
feat(alert): add an option to use a reverse proxied Telegram API server

### DIFF
--- a/lgsm/config-default/config-lgsm/acserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/acserver/_default.cfg
@@ -78,6 +78,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/ahl2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ahl2server/_default.cfg
@@ -84,6 +84,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/ahlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ahlserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/arkserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arkserver/_default.cfg
@@ -82,6 +82,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/arma3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arma3server/_default.cfg
@@ -95,6 +95,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/avserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/avserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/bb2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bb2server/_default.cfg
@@ -85,6 +85,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/bbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bbserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/bdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bdserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/bf1942server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bf1942server/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/bfvserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bfvserver/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/bmdmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bmdmserver/_default.cfg
@@ -85,6 +85,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/boserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/boserver/_default.cfg
@@ -78,6 +78,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/bsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bsserver/_default.cfg
@@ -89,6 +89,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/bt1944server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bt1944server/_default.cfg
@@ -77,6 +77,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/btserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/btserver/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/ccserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ccserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/cmwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cmwserver/_default.cfg
@@ -78,6 +78,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/cod2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cod2server/_default.cfg
@@ -78,6 +78,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/cod4server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cod4server/_default.cfg
@@ -78,6 +78,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/codserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/codserver/_default.cfg
@@ -78,6 +78,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/coduoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/coduoserver/_default.cfg
@@ -78,6 +78,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/codwawserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/codwawserver/_default.cfg
@@ -78,6 +78,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/colserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/colserver/_default.cfg
@@ -73,6 +73,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/csczserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csczserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -105,6 +105,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/csserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/cssserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cssserver/_default.cfg
@@ -85,6 +85,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/dabserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dabserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/dmcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dmcserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/dodserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dodserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/dodsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dodsserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/doiserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/doiserver/_default.cfg
@@ -81,6 +81,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/dstserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dstserver/_default.cfg
@@ -83,6 +83,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/dysserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dysserver/_default.cfg
@@ -85,6 +85,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/ecoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ecoserver/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/emserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/emserver/_default.cfg
@@ -85,6 +85,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/etlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/etlserver/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/fctrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/fctrserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/fofserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/fofserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/gmodserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/gmodserver/_default.cfg
@@ -92,6 +92,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/hldmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hldmserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/hldmsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hldmsserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/hwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hwserver/_default.cfg
@@ -91,6 +91,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/insserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/insserver/_default.cfg
@@ -86,6 +86,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/inssserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/inssserver/_default.cfg
@@ -82,6 +82,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/iosserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/iosserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/jc2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jc2server/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/jc3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jc3server/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/jk2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jk2server/_default.cfg
@@ -81,6 +81,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/kf2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/kf2server/_default.cfg
@@ -78,6 +78,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/kfserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/kfserver/_default.cfg
@@ -84,6 +84,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/l4d2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/l4d2server/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/l4dserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/l4dserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/mcbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mcbserver/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/mcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mcserver/_default.cfg
@@ -81,6 +81,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/mhserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mhserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/mohaaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mohaaserver/_default.cfg
@@ -77,6 +77,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/momserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/momserver/_default.cfg
@@ -78,6 +78,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/mtaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mtaserver/_default.cfg
@@ -76,6 +76,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/mumbleserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mumbleserver/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/ndserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ndserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
@@ -85,6 +85,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/ns2cserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ns2cserver/_default.cfg
@@ -87,6 +87,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/ns2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ns2server/_default.cfg
@@ -91,6 +91,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/nsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/nsserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/onsetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/onsetserver/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/opforserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/opforserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/pcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pcserver/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/pstbsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pstbsserver/_default.cfg
@@ -82,6 +82,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/pvkiiserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pvkiiserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/pvrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pvrserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/pzserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pzserver/_default.cfg
@@ -76,6 +76,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/q2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/q2server/_default.cfg
@@ -77,6 +77,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/q3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/q3server/_default.cfg
@@ -77,6 +77,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/qlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qlserver/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/qwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qwserver/_default.cfg
@@ -76,6 +76,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/ricochetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ricochetserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/roserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/roserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/rtcwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rtcwserver/_default.cfg
@@ -77,6 +77,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/rustserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rustserver/_default.cfg
@@ -87,6 +87,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/rwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rwserver/_default.cfg
@@ -75,6 +75,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/sampserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sampserver/_default.cfg
@@ -76,6 +76,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/sbotsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sbotsserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/sbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sbserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/scpslserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/scpslserver/_default.cfg
@@ -77,6 +77,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/scpslsmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/scpslsmserver/_default.cfg
@@ -77,6 +77,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
@@ -75,6 +75,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/sfcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sfcserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/sof2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sof2server/_default.cfg
@@ -77,6 +77,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/solserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/solserver/_default.cfg
@@ -76,6 +76,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/squadserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/squadserver/_default.cfg
@@ -77,6 +77,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/stserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/stserver/_default.cfg
@@ -82,6 +82,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/svenserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/svenserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/terrariaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/terrariaserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/tf2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tf2server/_default.cfg
@@ -85,6 +85,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/tfcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tfcserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/ts3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ts3server/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/tsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tsserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/tuserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tuserver/_default.cfg
@@ -82,6 +82,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/twserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/twserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/untserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/untserver/_default.cfg
@@ -78,6 +78,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/ut2k4server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut2k4server/_default.cfg
@@ -76,6 +76,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/ut3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut3server/_default.cfg
@@ -92,6 +92,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/ut99server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut99server/_default.cfg
@@ -76,6 +76,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/utserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/utserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/vhserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vhserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/vintsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vintsserver/_default.cfg
@@ -76,6 +76,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/vsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vsserver/_default.cfg
@@ -79,6 +79,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/wetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wetserver/_default.cfg
@@ -72,6 +72,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/wfserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wfserver/_default.cfg
@@ -77,6 +77,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/wurmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wurmserver/_default.cfg
@@ -73,6 +73,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/zmrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/zmrserver/_default.cfg
@@ -80,6 +80,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/config-default/config-lgsm/zpsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/zpsserver/_default.cfg
@@ -85,6 +85,7 @@ slackwebhook="webhook"
 # Telegram Alerts | https://docs.linuxgsm.com/alerts/telegram
 # You can add a custom cURL string eg proxy (useful in Russia) in "curlcustomstring".
 # For example "--socks5 ipaddr:port" for socks5 proxy see more in "curl --help".
+telegramapi="api.telegram.org"
 telegramalert="off"
 telegramtoken="accesstoken"
 telegramchatid=""

--- a/lgsm/functions/alert_telegram.sh
+++ b/lgsm/functions/alert_telegram.sh
@@ -17,7 +17,7 @@ EOF
 )
 
 fn_print_dots "Sending Telegram alert"
-telegramsend=$(curl --connect-timeout 10 -sSL -H "Content-Type: application/json" -X POST -d """${json}""" ${curlcustomstring} "https://api.telegram.org/bot${telegramtoken}/sendMessage" | grep "error_code")
+telegramsend=$(curl --connect-timeout 10 -sSL -H "Content-Type: application/json" -X POST -d """${json}""" ${curlcustomstring} "https://${telegramapi}/bot${telegramtoken}/sendMessage" | grep "error_code")
 
 if [ -n "${telegramsend}" ]; then
 	fn_print_fail_nl "Sending Telegram alert: ${telegramsend}"


### PR DESCRIPTION
# Description

TLDR: I add an option for user to use official Telegram API or their own Telegram API by hosting a reverse proxy server. Please give it a test by install a new server, I only tested on my existing tf2server.

One year ago I submit #2805 about using a proxy string for `curlcustomstring`. But the fact is in some area, most IDC will check whether your server is running proxy software to bypass the firewall. While running a socks5 proxy will be extremely easy to be spotted, it's much more reliable to run a reverse proxied Telegram API server somewhere else.

## Type of change

* [ ] Bug fix (a change which fixes an issue).
* [x] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

I don't know if the document for config a reverse proxy is needed.
