### PR TITLE
fix(vhserver): Add escaped quotes to Valheim startparams to account for spaces

### DIFF
--- a/lgsm/config-default/config-lgsm/vhserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vhserver/_default.cfg
@@ -17,7 +17,7 @@ gameworld="${selfname}"
 public="1"
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="-name '${servername}' -password ${serverpassword} -port ${port} -world ${gameworld} -public ${public}"
+startparameters="-name \"${servername}\" -password \"${serverpassword}\" -port ${port} -world \"${gameworld}\" -public ${public}"
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
# Description

The current single tick quotes do not work as intended when using spaces in the server name. 

I instead used escaped quotes (tested + working) and added it to the password and world name for sanities sake.

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.
