### PR TITLE
fix(info): get most recent backup instead of oldest

### DIFF
--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -205,7 +205,7 @@ if [ -d "${backupdir}" ]; then
 		# number of backups.
 		backupcount=$(find "${backupdir}"/*.tar.gz | wc -l)
 		# most recent backup.
-		lastbackup=$(find "${backupdir}"/*.tar.gz | head -1)
+		lastbackup=$(find "${backupdir}"/*.tar.gz | tail -1)
 		# date of most recent backup.
 		lastbackupdate=$(date -r "${lastbackup}")
 		# no of days since last backup.


### PR DESCRIPTION
# Description

The most recent backup was previously being chosen as the first file in the backup folder when it's actually the last.  This change fixes that issue.

Fixes #3307 

## Type of change

* [X] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [X] This pull request links to an issue.
* [X] This pull request uses the `develop` branch as its base.
* [X] This pull request Subject follows the Conventional Commits standard.
* [X] This code follows the style guidelines of this project.
* [X] I have performed a self-review of my code.
* [X] I have checked that this code is commented where required.
* [X] I have provided a detailed with enough description of this PR.
* [X] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**