### PR TITLE
Force $lastbackup to use latest backup.

### DIFF
--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -8,6 +8,10 @@
 
 functionselfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
 
+### Game Server pid
+if [ "${status}" == "1" ]; then
+	gameserverpid=$(tmux list-sessions -F "#{session_name} #{pane_pid}" | grep "^${sessionname} " | awk '{print $NF}')
+fi
 ### Distro information
 
 ## Distro
@@ -66,16 +70,16 @@ done
 glibcversion=$(ldd --version | sed -n '1s/.* //p')
 
 ## tmux version
-tmuxv=$(tmux -V | sed "s/tmux //")
-tmuxvdigit=$(echo "${tmuxv}" | tr -cd '[:digit:]')
-
-## Game Server pid
-if [ "${status}" == "1" ]&&[ "${tmuxv}" != "1.8" ]; then
-	gameserverpid=$(tmux list-sessions -F "#{session_name} #{pane_pid}" | grep "^${sessionname} " | awk '{print $NF}')
+# e.g: tmux 1.6
+if [ ! "$(command -V tmux 2>/dev/null)" ]; then
+	tmuxv="${red}NOT INSTALLED!${default}"
+else
+	if [ "$(tmux -V | sed "s/tmux //" | sed -n '1 p' | tr -cd '[:digit:]')" -lt "16" ]; then
+		tmuxv="$(tmux -V) (>= 1.6 required for console log)"
+	else
+		tmuxv=$(tmux -V)
+	fi
 fi
-
-## Date
-date="$(date)"
 
 ## Uptime
 uptime=$(</proc/uptime)
@@ -208,7 +212,7 @@ if [ -d "${backupdir}" ]; then
 		# number of backups.
 		backupcount=$(find "${backupdir}"/*.tar.gz | wc -l)
 		# most recent backup.
-		lastbackup=$(find "${backupdir}"/*.tar.gz | tail -1)
+		lastbackup=$(ls -1tr "${backupdir}"/*.tar.gz | head -1)
 		# date of most recent backup.
 		lastbackupdate=$(date -r "${lastbackup}")
 		# no of days since last backup.


### PR DESCRIPTION
# Description

Find does not sort results, it displays them in the order they are found.  In this case, this may usually be the order the backups are found, it is possible that it is not.  Also, `ls -1tr` is lighter than `find -print0 | sort -xargs 0`, and we're not using any of the advanced features of find.  So why not use a lighter command and force a sorted result where -head and -tail work well.

    Use `ls -1tr` in place of `find`
        * produce a simple list,
        * one item per line,
        * sorted by date reverse. (this is the part find does not do easily)

Fixes #[3319]

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
