### PR TITLE
Update command_start.sh to not quote command

### DIFF
--- a/lgsm/functions/command_start.sh
+++ b/lgsm/functions/command_start.sh
@@ -74,7 +74,7 @@ fn_start_tmux(){
 	echo "${version}" >> "${lockdir}/${selfname}.lock"
 	echo "${port}" >> "${lockdir}/${selfname}.lock"
 	cd "${executabledir}" || exit
-	tmux new-session -d -x "${sessionwidth}" -y "${sessionheight}" -s "${sessionname}" "${preexecutable} ${executable} ${parms}" 2> "${lgsmlogdir}/.${selfname}-tmux-error.tmp"
+	tmux new-session -d -x "${sessionwidth}" -y "${sessionheight}" -s "${sessionname}" ${preexecutable} ${executable} ${parms} 2> "${lgsmlogdir}/.${selfname}-tmux-error.tmp"
 
 	# Create logfile.
 	touch "${consolelog}"


### PR DESCRIPTION
Quoting the command and arguments causes tmux to treat it as a single command with spaces in it. Remove the quotes so tmux properly runs the command and passes arguments.

# Description

Please include a summary of the change and which issues are fixed.

Fixes #3239

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [ ] This pull request uses the `develop` branch as its base.
* [ ] This pull request Subject follows the Conventional Commits standard.
* [ ] This code follows the style guidelines of this project.
* [ ] I have performed a self-review of my code.
* [ ] I have checked that this code is commented where required.
* [ ] I have provided a detailed with enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
