### PR TITLE
fix: startparameters set instead of parms and call reload parms

### DIFF
--- a/lgsm/functions/command_start.sh
+++ b/lgsm/functions/command_start.sh
@@ -72,7 +72,7 @@ fn_start_tmux(){
 	echo "${version}" >> "${lockdir}/${selfname}.lock"
 	echo "${port}" >> "${lockdir}/${selfname}.lock"
 	cd "${executabledir}" || exit
-	tmux new-session -d -x "${sessionwidth}" -y "${sessionheight}" -s "${sessionname}" ${preexecutable} ${executable} ${parms} 2> "${lgsmlogdir}/.${selfname}-tmux-error.tmp"
+	tmux new-session -d -x "${sessionwidth}" -y "${sessionheight}" -s "${sessionname}" ${preexecutable} ${executable} ${startparameters} 2> "${lgsmlogdir}/.${selfname}-tmux-error.tmp"
 
 	# Create logfile.
 	touch "${consolelog}"

--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -466,7 +466,7 @@ else
 			eval startparameters="$(sed -nr 's/^ *startparameters=(.*)$/\1/p' "${configdirserver}/_default.cfg")"
 		fi
 	}
-
+	fn_reload_startparameters
 	# Load the linuxgsm.sh in to tmpdir. If missing download it.
 	if [ ! -f "${tmpdir}/linuxgsm.sh" ]; then
 		fn_fetch_file_github "" "linuxgsm.sh" "${tmpdir}" "chmodx" "norun" "noforcedl" "nohash"


### PR DESCRIPTION
# Description

startparameters set instead of parms and call function to eval parms once

fixes regression from #3315

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
