### PR TITLE
feature(rust): add option to set gamemode for server

### DIFF
--- a/lgsm/config-default/config-lgsm/rustserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rustserver/_default.cfg
@@ -16,6 +16,7 @@ appport=28082
 rconpassword="CHANGE_ME"
 rconweb="1" # Value is: 1 for the Facepunch web panel, Rustadmin desktop and Rustadmin Online; 0 for RCON tools like Rusty.
 servername="Rust"
+gamemode="vanilla" # values: vanilla, softcore ( Doc: https://wiki.facepunch.com/rust/server-gamemodes )
 maxplayers="50"
 seed="" # range: 1-2147483647, used to reproduce a procedural map.
 salt="" # range: unknown, used to recover a known setting from an existing map.
@@ -24,7 +25,7 @@ saveinterval="300" # Auto-save in seconds.
 tickrate="30" # default: 30, range: 15-100.
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="-batchmode +app.listenip ${ip} +app.port ${appport} +server.ip ${ip} +server.port ${port} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${selfname}\" +server.seed ${seed} +server.salt ${salt} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile"
+startparameters="-batchmode +app.listenip ${ip} +app.port ${appport} +server.ip ${ip} +server.port ${port} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${selfname}\" +server.gamemode ${gamemode} +server.seed ${seed} +server.salt ${salt} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile"
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
# Description

Add per default the gamemdoe option to the parameters and the default "vanilla" value to the config
New gamemodes will be also on this page: https://wiki.facepunch.com/rust/server-gamemodes

Fixes #3334 

## Type of change

* [ ] Bug fix (a change which fixes an issue).
* [x] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
