### PR TITLE
Revert "fix(vhserver): add escaped quotes to Valheim startparams to a…

### DIFF
--- a/lgsm/config-default/config-lgsm/vhserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vhserver/_default.cfg
@@ -18,7 +18,7 @@ public="1"
 savedir="$HOME/.config/unity3d/IronGate/Valheim"
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="-name \"${servername}\" -password \"${serverpassword}\" -port ${port} -world \"${gameworld}\" -public ${public} -savedir \"${savedir}\""
+startparameters="-name '${servername}' -password ${serverpassword} -port ${port} -world ${gameworld} -public ${public} -savedir '${savedir}'"
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
…ccount for spaces (#3272)"

This reverts commit 8db3b6d48740817eec2c337f6e579c9064ec9e74.

# Description

Reverting this commit as causing issues with password. I will investigate start parameters for Valheim further as getting odd behaviour in general.

Fixes #3367

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [ ] This pull request uses the `develop` branch as its base.
* [ ] This pull request Subject follows the Conventional Commits standard.
* [ ] This code follows the style guidelines of this project.
* [ ] I have performed a self-review of my code.
* [ ] I have checked that this code is commented where required.
* [ ] I have provided a detailed with enough description of this PR.
* [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
