### PR TITLE
fix(valheim): disable queryport if public is set to 0

### DIFF
--- a/lgsm/functions/info_parms.sh
+++ b/lgsm/functions/info_parms.sh
@@ -237,7 +237,11 @@ fn_info_parms_ut(){
 
 fn_info_parms_vh(){
 	port=${port:-"0"}
-	queryport=$((port + 1))
+	if [ "${public}" != "0" ]; then
+		queryport=$((port + 1))
+	else
+		querymode="1"
+	fi
 	gameworld=${gameworld:-"NOT SET"}
 	serverpassword=${serverpassword:-"NOT SET"}
 	servername=${servername:-"NOT SET"}


### PR DESCRIPTION
# Description

Disabled gameserver query if public is set to 0. When the server is in private mode the query port becomes disabled

Fixes #3337 

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
