### PR TITLE
feat(stats): allow stats on which alerts are being used

### DIFF
--- a/lgsm/functions/core_functions.sh
+++ b/lgsm/functions/core_functions.sh
@@ -523,11 +523,6 @@ functionfile="${FUNCNAME[0]}"
 fn_fetch_function
 }
 
-info_gamedig.sh(){
-functionfile="${FUNCNAME[0]}"
-fn_fetch_function
-}
-
 info_messages.sh(){
 functionfile="${FUNCNAME[0]}"
 fn_fetch_function

--- a/lgsm/functions/info_game.sh
+++ b/lgsm/functions/info_game.sh
@@ -1511,12 +1511,11 @@ fn_info_game_source(){
 	rconport=${port:-"0"}
 	queryport=${port:-"0"}
 	clientport=${clientport:-"0"}
-	# Steamport can be between 26901-26910 and is normaly automaticly set.
+	# Steamport can be between 26901-26910 and is normaly automatically set.
 	# Some servers might support -steamport parameter to set
-	if [ "${steamport}" == "0" ]||[ -z "${steamport}" ]; then
+	if [ "${steamport}" == "0" ]||[ -v "${steamport}" ]; then
 		steamport="$(echo "${ssinfo}" | grep "${srcdslinuxpid}" | awk '{print $5}' | grep ":269" | cut -d ":" -f2)"
 	fi
-	steamport="${steamport:-"0"}"
 }
 
 fn_info_game_spark(){

--- a/lgsm/functions/info_messages.sh
+++ b/lgsm/functions/info_messages.sh
@@ -1339,8 +1339,10 @@ fn_info_message_source(){
 		fn_port "Query" queryport tcp
 		fn_port "RCON" rconport tcp
 		fn_port "SourceTV" sourcetvport udp
-		# not manualy set by default more research needed
-		fn_port "Steam" steamport udp
+		# Will not show if unaviable
+		if [ "${steamport}" == "0" ]||[ -z "${steamport}" ]; then
+			fn_port "Steam" steamport udp
+		fi
 		fn_port "Client" clientport udp
 	} | column -s $'\t' -t
 }

--- a/lgsm/functions/info_messages.sh
+++ b/lgsm/functions/info_messages.sh
@@ -686,7 +686,7 @@ fn_info_message_ports(){
 	elif [ "${engine}" == "goldsrc" ]; then
 		echo -e "ss -tuplwn | grep hlds_linux"
 	else
-		executableshort="$(echo "${executable//.\/}" | cut -c -15)"
+		executableshort="$(basename "${executable}" | cut -c -15)"
 		echo -e "ss -tuplwn | grep ${executableshort}"
 	fi
 	echo -e ""
@@ -1713,8 +1713,7 @@ fn_info_message_select_engine(){
 		fn_info_message_spark
 	elif [ "${engine}" == "unreal" ]; then
 		fn_info_message_unreal
-
 	else
-		fn_print_error_nl "Unable to detect server engine."
+		fn_print_error_nl "Unable to detect game server."
 	fi
 }

--- a/lgsm/functions/info_stats.sh
+++ b/lgsm/functions/info_stats.sh
@@ -154,9 +154,9 @@ if [ "${telegramalert}" == "on" ]; then
 fi
 
 ## Summary Stats
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=summary" -d "ea=GAME: ${gamename} | DISTRO: ${distroname} | CPU MODEL: ${cpumodel} ${cpucores} cores | RAM: ${physmemtotal} | DISK: ${totalspace}" -d "v=1" > /dev/null 2>&1
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=summary" -d "ea=GAME: ${gamename} | DISTRO: ${distroname} | CPU MODEL: ${cpumodel} ${cpucores} cores | RAM: ${physmemtotal} | DISK: ${totalspace}" -d "v=1" > /dev/null 2>&1
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=summary" -d "ea=GAME: ${gamename} | DISTRO: ${distroname} | CPU MODEL: ${cpumodel} ${cpucores} cores | RAM: ${physmemtotal} | DISK: ${totalspace}" -d "v=1" > /dev/null 2>&1
+curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=summary" -d "ea=GAME: ${gamename} | DISTRO: ${distroname} | CPU MODEL: ${cpumodel} ${cpucores} cores | RAM: ${physmemtotal} | DISK: ${totalspace}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=summary" -d "ea=GAME: ${gamename} | DISTRO: ${distroname} | CPU MODEL: ${cpumodel} ${cpucores} cores | RAM: ${physmemtotal} | DISK: ${totalspace}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=summary" -d "ea=GAME: ${gamename} | DISTRO: ${distroname} | CPU MODEL: ${cpumodel} ${cpucores} cores | RAM: ${physmemtotal} | DISK: ${totalspace}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 
 fn_script_log_info "Send LinuxGSM stats"
 fn_script_log_info "* uuid-${selfname}: ${uuidinstance}"

--- a/lgsm/functions/info_stats.sh
+++ b/lgsm/functions/info_stats.sh
@@ -62,40 +62,34 @@ memusedroundup="$(((memused + 99) / 100 * 100))"
 # Hardware Property - UA-165287622-3
 
 ## Distro.
-curl https://www.google-analytics.com/collect -d "tid=UA-655379-31" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=distro" -d "ea=${distroname}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=distro" -d "ea=${distroname}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=distro" -d "ea=${distroname}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=distro" -d "ea=${distroname}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 
 ## Game Server Name.
-curl https://www.google-analytics.com/collect -d "tid=UA-655379-31" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=game" -d "ea=${gamename}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=game" -d "ea=${gamename}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=game" -d "ea=${gamename}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=game" -d "ea=${gamename}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 
 ## LinuxGSM Version.
-curl https://www.google-analytics.com/collect -d "tid=UA-655379-31" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=version" -d "ea=${version}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=version" -d "ea=${version}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=version" -d "ea=${version}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=version" -d "ea=${version}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 
 ## CPU usage of a game server.
 if [ -n "${cpuusedmhzroundup}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-655379-31" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=cpuused" -d "ea=${cpuusedmhzroundup}MHz" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=cpuused" -d "ea=${cpuusedmhzroundup}MHz" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=cpuused" -d "ea=${cpuusedmhzroundup}MHz" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=cpuused" -d "ea=${cpuusedmhzroundup}MHz" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 fi
 ## Ram usage of a game server.
 if [ -n "${memusedroundup}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-655379-31" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=ramused" -d "ea=${memusedroundup}MB" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=ramused" -d "ea=${memusedroundup}MB" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=ramused" -d "ea=${memusedroundup}MB" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=ramused" -d "ea=${memusedroundup}MB" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 fi
 ## Disk usage of a game server.
 if [ -n "${serverfilesdu}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-655379-31" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=diskused" -d "ea=${serverfilesdu}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=diskused" -d "ea=${serverfilesdu}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=diskused" -d "ea=${serverfilesdu}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=diskused" -d "ea=${serverfilesdu}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
@@ -103,7 +97,6 @@ fi
 
 ## CPU Model.
 if [ -n "${cpumodel}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-655379-31" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=servercpu" -d "ea=${cpumodel} ${cpucores} cores" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=servercpu" -d "ea=${cpumodel} ${cpucores} cores" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=servercpu" -d "ea=${cpumodel} ${cpucores} cores" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=servercpu" -d "ea=${cpumodel} ${cpucores} cores" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
@@ -112,7 +105,6 @@ fi
 
 ## CPU Frequency.
 if [ -n "${cpufreqency}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-655379-31" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=servercpufreq" -d "ea=${cpufreqency} x${cpucores}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=servercpufreq" -d "ea=${cpufreqency} x${cpucores}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=servercpufreq" -d "ea=${cpufreqency} x${cpucores}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=servercpufreq" -d "ea=${cpufreqency} x${cpucores}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
@@ -120,7 +112,6 @@ fi
 
 ## Server RAM.
 if [ -n "${physmemtotal}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-655379-31" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=serverram" -d "ea=${physmemtotal}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=serverram" -d "ea=${physmemtotal}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=serverram" -d "ea=${physmemtotal}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=serverram" -d "ea=${physmemtotal}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
@@ -128,14 +119,41 @@ fi
 
 ## Server Disk.
 if [ -n "${totalspace}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-655379-31" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=serverdisk" -d "ea=${totalspace}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=serverdisk" -d "ea=${totalspace}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=serverdisk" -d "ea=${totalspace}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=serverdisk" -d "ea=${totalspace}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 fi
 
+## Alert Stats.
+if [ "${discordalert}" == "on" ]; then
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${discordalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+fi
+if [ "${emailalert}" == "on" ]; then
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${emailalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+fi
+if [ "${iftttalert}" == "on" ]; then
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${iftttalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+fi
+if [ "${mailgunalert}" == "on" ]; then
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${mailgunalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+fi
+if [ "${pushbulletalert}" == "on" ]; then
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${pushbulletalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+fi
+if [ "${pushoveralert}" == "on" ]; then
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${pushoveralert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+fi
+if [ "${rocketchatalert}" == "on" ]; then
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${rocketchatalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+fi
+if [ "${slackalert}" == "on" ]; then
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${slackalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+fi
+if [ "${telegramalert}" == "on" ]; then
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${telegramalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+fi
+
 ## Summary Stats
-curl https://www.google-analytics.com/collect -d "tid=UA-655379-31" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=summary" -d "ea=GAME: ${gamename} | DISTRO: ${distroname} | CPU MODEL: ${cpumodel} ${cpucores} cores | RAM: ${physmemtotal} | DISK: ${totalspace}" -d "v=1" > /dev/null 2>&1
 curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=summary" -d "ea=GAME: ${gamename} | DISTRO: ${distroname} | CPU MODEL: ${cpumodel} ${cpucores} cores | RAM: ${physmemtotal} | DISK: ${totalspace}" -d "v=1" > /dev/null 2>&1
 curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=summary" -d "ea=GAME: ${gamename} | DISTRO: ${distroname} | CPU MODEL: ${cpumodel} ${cpucores} cores | RAM: ${physmemtotal} | DISK: ${totalspace}" -d "v=1" > /dev/null 2>&1
 curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=summary" -d "ea=GAME: ${gamename} | DISTRO: ${distroname} | CPU MODEL: ${cpumodel} ${cpucores} cores | RAM: ${physmemtotal} | DISK: ${totalspace}" -d "v=1" > /dev/null 2>&1

--- a/lgsm/functions/info_stats.sh
+++ b/lgsm/functions/info_stats.sh
@@ -126,31 +126,31 @@ fi
 
 ## Alert Stats.
 if [ "${discordalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${discordalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Discord" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 fi
 if [ "${emailalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${emailalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Email" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 fi
 if [ "${iftttalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${iftttalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=IFTTT" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 fi
 if [ "${mailgunalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${mailgunalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Mailgun" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 fi
 if [ "${pushbulletalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${pushbulletalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Pushbullet" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 fi
 if [ "${pushoveralert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${pushoveralert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Pushover" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 fi
 if [ "${rocketchatalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${rocketchatalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Rocket Chat" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 fi
 if [ "${slackalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${slackalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Slack" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 fi
 if [ "${telegramalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=${telegramalert}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
+	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Telegram" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 fi
 
 ## Summary Stats


### PR DESCRIPTION
# Description

This PR will add stats collection on alert types being used in LinuxGSM. This info will be added to the [LinuxGSM stats dashboard](https://linuxgsm.com/data/usage/) and will allow us to see which types of Alerts users prefer. This will help guide development priorities and future alert additions.

Fixes #3551

## Type of change

* [ ] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [x] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
