### PR TITLE
feat(github): Allow to set  github user, repo and branch at runtime with environment variable

### DIFF
--- a/linuxgsm.sh
+++ b/linuxgsm.sh
@@ -47,9 +47,9 @@ userinput2="${2}"
 ## GitHub Branch Select
 # Allows for the use of different function files
 # from a different repo and/or branch.
-githubuser="GameServerManagers"
-githubrepo="LinuxGSM"
-githubbranch="master"
+[ -n "${LGSM_GITHUBUSER}" ] && githubuser="${LGSM_GITHUBUSER}" || githubuser="GameServerManagers"
+[ -n "${LGSM_GITHUBREPO}" ] && githubrepo="${LGSM_GITHUBREPO}" || githubrepo="LinuxGSM"
+[ -n "${LGSM_GITHUBBRANCH}" ] && githubbranch="${LGSM_GITHUBBRANCH}" || githubbranch="master"
 
 # Core function that is required first.
 core_functions.sh(){


### PR DESCRIPTION
# Description

Add a way to set github user, repo and branch at runtime  with 3 env var instead of creating/editing variables githubuser, githubrepo and githubbranch in source file.
* LGSM_GITHUBUSER
* LGSM_GITHUBREPO
* LGSM_GITHUBBRANCH


Usefull in any automate use case.
This help a lot when automate deployment processus
It helps automation from the very begining when just calling at first step linuxgsm.sh and also for the other steps (./gameserver.sh install) without editing nor creating files.
One use case is when playing with docker where we use a lot of env var to automatize workflow.


This feature is an option, it does not break the previous way of using lgsm

## Type of change

* [ ] Bug fix (a change which fixes an issue).
* [X] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [X] This pull request uses the `develop` branch as its base.
* [X] This pull request Subject follows the Conventional Commits standard.
* [X] This code follows the style guidelines of this project.
* [X] I have performed a self-review of my code.
* [X] I have checked that this code is commented where required.
* [X] I have provided a detailed with enough description of this PR.
* [X] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
