### PR TITLE
fix: #1868 mods lowercase conversion

### DIFF
--- a/lgsm/functions/mods_core.sh
+++ b/lgsm/functions/mods_core.sh
@@ -50,7 +50,6 @@ fn_mod_lowercase(){
 			# therefore, we have to separate the end of the filename to only lowercase it rather than the whole line
 			# Gather parent dir, filename lowercase filename, and set lowercase destination name
 			latestparentdir=$(dirname "${src}")
-			latestfile=$(basename "${src}")
 			latestfilelc=$(basename "${src}" | tr '[:upper:]' '[:lower:]')
 			dst="${latestparentdir}/${latestfilelc}"
 			# Only convert if destination does not already exist for some reason


### PR DESCRIPTION
# Description

Major refactor of fn_mod_lowercase()
Finally fixes mods lowercase conversion

Fixes #1868

## Type of change

* [ ] Bug fix (a change which fixes an issue).


# Sample output
```
Installing DarkRP
=================================
creating mod download directory /home/ulti/lgsm/mods/tmp...OK
                                #=#=-  #       #                                                                                                                                                                                                       ################################################################################################################################################################################################################################################ 100.0%   -#O=-   #         #           #                                                                                                                                                                                                                    
extracting darkrp-master.zip...OK
converting DarkRP files to lowercase...Found 19 uppercase files out of 588, converting...OK
building darkrp-files.txt...OK
copying DarkRP to /home/ulti/serverfiles/garrysmod/gamemodes...OK
tidy up darkrp-files.txt...OK
clearing mod download directory /home/ulti/lgsm/mods/tmp...OK
DarkRP installed

# ls serverfiles/garrysmod/gamemodes/darkrp-master/
 content   contributing.md   darkrp.txt  "don't touch any of these files.txt"   entities   gamemode   glualint.json   help   icon24.png   issue_template.md   license.txt   logo.png   readme.md

```