### PR TITLE
fix(pzserver): start with --ip instead of -ip

### DIFF
--- a/lgsm/config-default/config-lgsm/pzserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pzserver/_default.cfg
@@ -13,7 +13,7 @@ ip="0.0.0.0"
 adminpassword="CHANGE_ME"
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="-ip ${ip} -adminpassword \"${adminpassword}\" -servername ${selfname}"
+startparameters="--ip ${ip} -adminpassword \"${adminpassword}\" -servername ${selfname}"
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
# Description

`-ip` is not parsed correctly by the new build 41 release. See https://github.com/GameServerManagers/LinuxGSM/discussions/3711#discussioncomment-1844368

Fixes #3711 

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [X] This pull request links to an issue.
* [X] This pull request uses the `develop` branch as its base.
* [X] This pull request Subject follows the Conventional Commits standard.
* [X] This code follows the style guidelines of this project.
* [X] I have performed a self-review of my code.
* [X] I have checked that this code is commented where required.
* [X] I have provided a detailed with enough description of this PR.
* [X] I have checked If documentation needs updating.