### PR TITLE
fix(vh): log a message when the password is not set or to short

### DIFF
--- a/lgsm/functions/check_config.sh
+++ b/lgsm/functions/check_config.sh
@@ -25,3 +25,11 @@ elif [ -v rconpassword ]&&[ "${rconpassword}" == "CHANGE_ME" ]; then
 	fn_print_warn_nl "Default RCON Password detected"
 	fn_script_log_warn "Default RCON Password detected"
 fi
+
+if [ "${shortname}" == "vh" ]&&[ -z "${serverpassword}" ]; then
+	fn_print_fail_nl "serverpassword is not set"
+	fn_script_log_fatal "serverpassword is not set"
+elif [ "${shortname}" == "vh" ]&&[ "${#serverpassword}" -le "4" ]; then
+	fn_print_fail_nl "serverpassword is to short (min 5 chars)"
+	fn_script_log_fatal "serverpassword is to short (min 5 chars)"
+fi


### PR DESCRIPTION
# Description

Give a message to the user, when the password is not long enough

Fixes #3737

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
