### PR TITLE
fix(sdtdserver): monitor command fails

### DIFF
--- a/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
@@ -140,7 +140,7 @@ stopmode="8"
 # 3: gamedig
 # 4: gsquery
 # 5: tcp
-querymode="2"
+querymode="5"
 querytype="protocol-valve"
 
 ## Console type


### PR DESCRIPTION
# Description

7 Days to Die no longer supports the UDP `protocol-valve` for gamedig and gsquery. This causes the monitor to always fail and restart the server.

To fix this, switch to the `tcp` query mode. This matches the info shown in the `details` output:

```
DESCRIPTION  PORT   PROTOCOL  LISTEN
Game         26900  udp       1
Game+2       26902  udp       2
Query        26900  tcp       1
Web Admin    8080   tcp       0
Telnet       8081   tcp       1
```

Fixes #3619
Related to #3701

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

N/A