### PR TITLE
Only compare first 5 chars of distroversion

### DIFF
--- a/lgsm/functions/check_deps.sh
+++ b/lgsm/functions/check_deps.sh
@@ -19,11 +19,11 @@ fn_install_mono_repo(){
 		sleep 1
 		echo -en "   \r"
 		if [ "${distroid}" == "ubuntu" ]; then
-			if [ "${distroversion}" == "20.04" ]; then
+			if [ "${distroversion:0:5}" == "20.04" ]; then
 				cmd="sudo apt install gnupg ca-certificates;sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF;echo 'deb https://download.mono-project.com/repo/ubuntu stable-focal main' | sudo tee /etc/apt/sources.list.d/mono-official-stable.list;sudo apt update"
-			elif [ "${distroversion}" == "18.04" ]; then
+			elif [ "${distroversion:0:5}" == "18.04" ]; then
 				cmd="sudo apt install gnupg ca-certificates;sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF;echo 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main' | sudo tee /etc/apt/sources.list.d/mono-official-stable.list;sudo apt update"
-			elif [ "${distroversion}" == "16.04" ]; then
+			elif [ "${distroversion:0:5}" == "16.04" ]; then
 				cmd="sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF;sudo apt install apt-transport-https ca-certificates;echo 'deb https://download.mono-project.com/repo/ubuntu stable-xenial main' | sudo tee /etc/apt/sources.list.d/mono-official-stable.list;sudo apt update"
 			else
 				monoautoinstall="1"


### PR DESCRIPTION
# Description

I've been trying to work on a simple cloud-init script for provisioning a cloud server with LGSM / csgoserver. I noticed in the output of the install the message `Warning! LinuxGSM dependency checking currently unavailable for Ubuntu 20.04.3 LTS.` was output and the required dependencies were not installed. Note the version number is `20.04.3` not `20.04`.

This fix should mean that only the first 5 characters of the versions number are compared (eg: 20.04 instead of 20.04.3).

Fixes #[issue]

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [ ] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
