### PR TITLE
refactor: move steammaster check to info_game

### DIFF
--- a/lgsm/functions/info_distro.sh
+++ b/lgsm/functions/info_distro.sh
@@ -267,61 +267,6 @@ fi
 netint=$(${ipcommand} -o addr | grep "${ip}" | awk '{print $2}')
 netlink=$(${ethtoolcommand} "${netint}" 2>/dev/null| grep Speed | awk '{print $2}')
 
-# External IP address
-if [ -z "${extip}" ]; then
-	extip="$(curl --connect-timeout 10 -s https://api.ipify.org 2>/dev/null)"
-	exitcode=$?
-	# Should ifconfig.co return an error will use last known IP.
-	if [ ${exitcode} -eq 0 ]; then
-		if [[ "${extip}" != *"DOCTYPE"* ]]; then
-			echo -e "${extip}" > "${tmpdir}/extip.txt"
-		else
-			if [ -f "${tmpdir}/extip.txt" ]; then
-				extip="$(cat "${tmpdir}/extip.txt")"
-			else
-				fn_print_error_nl "Unable to get external IP"
-			fi
-		fi
-	else
-		if [ -f "${tmpdir}/extip.txt" ]; then
-			extip="$(cat "${tmpdir}/extip.txt")"
-		else
-			fn_print_error_nl "Unable to get external IP"
-		fi
-	fi
-fi
-
-# Alert IP address
-if [ "${displayip}" ]; then
-	alertip="${displayip}"
-elif [ "${extip}" ]; then
-	alertip="${extip}"
-else
-	alertip="${ip}"
-fi
-
-# Steam Master Server - checks if detected by master server.
-if [ -z "${displaymasterserver}" ]; then
-	if [ "$(command -v jq 2>/dev/null)" ]; then
-		if [ "${ip}" ]&&[ "${port}" ]; then
-			if [ "${steammaster}" == "true" ]||[ "${commandname}" == "DEV-QUERY-RAW" ]; then
-				# Will query server IP addresses first.
-				for queryip in "${queryips[@]}"; do
-					masterserver="$(curl --connect-timeout 10 -m 3 -s "https://api.steampowered.com/ISteamApps/GetServersAtAddress/v0001?addr=${queryip}&format=json" | jq --arg port "${port}" --arg queryport "${queryport}" '.response.servers[] | select((.gameport == ($port|tonumber) or (.gameport == ($queryport|tonumber)))) | .addr' | wc -l 2>/dev/null)"
-				done
-				# Should that not work it will try the external IP.
-				if [ "${masterserver}" == "0" ]; then
-					masterserver="$(curl --connect-timeout 10 -m 3 -s "https://api.steampowered.com/ISteamApps/GetServersAtAddress/v0001?addr=${extip}&format=json" | jq --arg port "${port}" --arg queryport "${queryport}" '.response.servers[] | select((.gameport == ($port|tonumber) or (.gameport == ($queryport|tonumber)))) | .addr' | wc -l 2>/dev/null)"
-				fi
-				if [ "${masterserver}" == "0" ]; then
-					displaymasterserver="false"
-				else
-					displaymasterserver="true"
-				fi
-			fi
-		fi
-	fi
-fi
 # Sets the SteamCMD glibc requirement if the game server requirement is less or not required.
 if [ "${appid}" ]; then
 	if [ "${glibc}" = "null" ]||[ -z "${glibc}" ]||[ "$(printf '%s\n'${glibc}'\n' "2.14" | sort -V | head -n 1)" != "2.14" ]; then


### PR DESCRIPTION
## Description

move steammaster check and extip code to info_game.
This is needed that the queryport for some games is only in the info_game.sh

Fixes #3762

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [x] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
