### PR TITLE
fix (arma3server): prevent multiple loading mods failing due to accidental line termination

### DIFF
--- a/lgsm/config-default/config-lgsm/arma3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arma3server/_default.cfg
@@ -32,7 +32,7 @@ servermods=""
 bepath=""
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="-ip=${ip} -port=${port} -cfg=${networkcfgfullpath} -config=${servercfgfullpath} -mod=${mods} -servermod=${servermods} -bepath=${bepath} -autoinit -loadmissiontomemory"
+startparameters="-ip=${ip} -port=${port} -cfg=${networkcfgfullpath} -config=${servercfgfullpath} -mod='${mods}' -servermod=${servermods} -bepath=${bepath} -autoinit -loadmissiontomemory"
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
Fixes loading multiple mods failing due to accidental line termination in the mod string when following the documentation. (Observed on Ubuntu 20.10)


If you want this linked to an issue then reject the pull request.