### PR TITLE
Networking and server rebuild update

### DIFF
--- a/lgsm/config-default/config-lgsm/stserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/stserver/_default.cfg
@@ -9,17 +9,12 @@
 #### Game Server Settings ####
 
 ## Predefined Parameters | https://docs.linuxgsm.com/configuration/start-parameters
-ip="0.0.0.0"
-port="27500"
-queryport="27015"
 worldtype="Moon"
-autosaveinterval=300
-clearinterval=60
 worldname="moon_save"
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
 # Edit with care
-startparameters="-batchmode -nographics -autostart -gameport=${port} -updateport=${queryport} -worldtype=${worldtype} -loadworld=${worldname} -worldname=${worldname} -autosaveinterval=${autosaveinterval} -clearallinterval=${clearinterval}"
+startparameters=" -NEWGAME=${worldtype} -LOADGAME=${worldname}"
 
 #### LinuxGSM Settings ####
 
@@ -139,7 +134,7 @@ steammaster="false"
 # 9: GoldSrc
 # 10: Avorion
 # 11: end
-stopmode="2"
+stopmode="3"
 
 ## Query mode
 # 1: session only
@@ -168,8 +163,6 @@ systemdir="${serverfiles}"
 executabledir="${serverfiles}"
 executable="./rocketstation_DedicatedServer.x86_64"
 servercfgdir="${systemdir}"
-servercfg="default.ini"
-servercfgdefault="default.ini"
 servercfgfullpath="${servercfgdir}/${servercfg}"
 
 ## Backup Directory


### PR DESCRIPTION
Networking and the server has been rebuild from scratch many commands have been lost and shutdown has changed.

# Description
Removed:
ip, port, queryport, autosaveinterval, clearinterval
These are now all defined in setting.xml and can't be defined on the commandline anymore
default.ini got removed

Modified:
worldtype & worldname to correct commands
stopmode changed, it needs a quit command now in the console

# Comment
The network changes have been live now for 2 weeks, server has been updated for 2 days expect more changes to follow.