### PR TITLE
fix(deps): fix java and rng dependency for pz and rw

### DIFF
--- a/lgsm/data/ubuntu-20.04.csv
+++ b/lgsm/data/ubuntu-20.04.csv
@@ -79,7 +79,7 @@ pmc,openjdk-17-jre
 pstbs,libgconf-2-4
 pvkii
 pvr,libc++1
-pz,openjdk-16-jre,rng-tools
+pz,openjdk-17-jre,rng-tools
 q2
 q3
 ql
@@ -88,7 +88,7 @@ ricochet
 ro
 rtcw
 rust,lib32z1
-rw,openjdk-16-jre
+rw,openjdk-17-jre
 samp
 sb
 sbots

--- a/lgsm/data/ubuntu-21.04.csv
+++ b/lgsm/data/ubuntu-21.04.csv
@@ -79,7 +79,7 @@ pmc,openjdk-17-jre
 pstbs,libgconf-2-4
 pvkii
 pvr,libc++1
-pz,openjdk-16-jre,rng-tools
+pz,openjdk-17-jre,rng-tools
 q2
 q3
 ql
@@ -88,7 +88,7 @@ ricochet
 ro
 rtcw
 rust,lib32z1
-rw,openjdk-16-jre
+rw,openjdk-17-jre
 samp
 sb
 sbots

--- a/lgsm/data/ubuntu-21.10.csv
+++ b/lgsm/data/ubuntu-21.10.csv
@@ -77,7 +77,7 @@ pmc,openjdk-17-jre
 pstbs,libgconf-2-4
 pvkii
 pvr,libc++1
-pz,openjdk-16-jre,rng-tools
+pz,openjdk-17-jre,rng-tools
 q2
 q3
 ql
@@ -86,7 +86,7 @@ ricochet
 ro
 rtcw
 rust,lib32z1
-rw,openjdk-16-jre
+rw,openjdk-17-jre
 samp
 sb
 sbots

--- a/lgsm/data/ubuntu-22.04.csv
+++ b/lgsm/data/ubuntu-22.04.csv
@@ -77,7 +77,7 @@ pmc,openjdk-17-jre
 pstbs,libgconf-2-4
 pvkii
 pvr,libc++1
-pz,openjdk-16-jre,rng-tools
+pz,openjdk-17-jre,rng-tools5
 q2
 q3
 ql
@@ -86,7 +86,7 @@ ricochet
 ro
 rtcw
 rust,lib32z1
-rw,openjdk-16-jre
+rw,openjdk-17-jre
 samp
 sb
 sbots


### PR DESCRIPTION
# Description

Fixes the dependencys for rw and pz on Ubuntu
On Ubuntu only on a few the package openjdk-16-jre does still exist, so i replaced here all occourences for this.
Also rng-tools has a new package with the name rng-tools5 in ubuntu 22.04 - changes this as well.
Edit: java 17 is LST, this is why this makes sense to update to this version.

Fixes #3910

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**