### PR TITLE
feat(st): switch parameters to loadlatest

### DIFF
--- a/lgsm/config-default/config-lgsm/stserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/stserver/_default.cfg
@@ -20,7 +20,7 @@ worldname="moon_save"
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
 # Edit with care
-startparameters="-NEWGAME ${worldtype} -LOADGAME ${worldname} -settings ServerName ${servername} StartLocalHost true ServerVisible true ServerMaxPlayers ${maxplayers} GamePort ${port} UpdatePort ${queryport} UPNPEnabled true AutoSave true SaveInterval ${autosaveinterval}"
+startparameters="-LOADLATEST ${worldname} ${worldtype} -settings ServerName ${servername} StartLocalHost true ServerVisible true ServerMaxPlayers ${maxplayers} GamePort ${port} UpdatePort ${queryport} UPNPEnabled true AutoSave true SaveInterval ${autosaveinterval}"
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
There are some unforseen issues if you both specify load and new together.
Loadlatest will also grab the last backup of that same save.

Fixes:

* Bug Fix: Specifying new and load together spawned a lander (starting new world supplies) every time the server was restarted.