### PR TITLE
fix(csgo): move away old libgcc_s.so.1 to fix sourcemod

### DIFF
--- a/lgsm/functions/fix_csgo.sh
+++ b/lgsm/functions/fix_csgo.sh
@@ -31,3 +31,12 @@ if [ -f "${servercfgdir}/valve.rc" ] && grep -E '^\s*exec\s*(default|joystick)\.
 	sed -i 's/^\s*exec\s*joystick.cfg/\/\/exec joystick.cfg/g' "${servercfgdir}/valve.rc" > /dev/null 2>&1
 	fn_fix_msg_end
 fi
+
+# Fixes: Detected engine 11 but could not load: /home/csgo/serverfiles/bin/libgcc_s.so.1: version `GCC_7.0.0' not found (required by /lib/i386-linux-gnu/libstdc++.so.6)
+libgccc_so="${serverfiles}/bin/libgcc_s.so.1"
+if [ -f "${libgccc_so}" ]; then
+	fixname="libgcc_s.so.1 move away"
+	fn_fix_msg_start
+	mv -v "${libgccc_so}" "${libgccc_so}.bck"
+	fn_fix_msg_end
+fi


### PR DESCRIPTION
# Description

With the incompatibility of the `libgcc_s.so.1` with Ubuntu 22.04 we just move away the lib to use the system lib instead.
Fixes #3958

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.
* User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
* Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**