### PR TITLE
fix(wmcserver): Fix not being able to read query port

### DIFF
--- a/lgsm/functions/info_game.sh
+++ b/lgsm/functions/info_game.sh
@@ -2265,7 +2265,7 @@ fn_info_game_wmc(){
 
 		# Not set
 		servername=${servername:-"NOT SET"}
-		queryport=${rconpassword:-"NOT SET"}
+		queryport=${queryport:-"25577"}
 		maxplayers=${maxplayers:-"0"}
 		configip=${configip:-"0.0.0.0"}
 	fi


### PR DESCRIPTION
# Description

queryport was being overwritten with rconpassword or "NOT SET"

Fixes #3981

## Type of change

* [x] Bug fix (a change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed with enough description of this PR.
* [x] I have checked If documentation needs updating.
