### PR TITLE
feat(csgoserver): add all game mode related cvars to CS:GO LGSM config

### DIFF
--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -10,15 +10,23 @@
 
 ## Predefined Parameters | https://docs.linuxgsm.com/configuration/start-parameters
 # https://docs.linuxgsm.com/game-servers/counter-strike-global-offensive
-# [Game Modes]			gametype	gamemode	mapgroup (you can mix these across all Game Modes except Danger Zone, but use only one)
-# Arms Race				1			0			mg_armsrace
-# Classic Casual		0			0			mg_casualsigma, mg_casualdelta
-# Classic Competitive	0			1			mg_active, mg_reserves, mg_hostage, mg_de_dust2
-# Custom				3			0
-# Deathmatch			1			2			mg_deathmatch
-# Demolition			1			1			mg_demolition
-# Wingman				0			2
-# Danger Zone			6			0			mg_dz_blacksite (map: dz_blacksite), mg_dz_sirocco (map: dz_sirocco)
+# [Game Modes]						gametype	gamemode	gamemodeflags	skirmishid	mapgroup (you can mix these across all Game Modes except Danger Zone, but use only one)
+# Arms Race							1			0			0				0			mg_armsrace
+# Boom! Headshot!					1			2			0				6			mg_skirmish_headshots
+# Classic Casual					0			0			0				0			mg_casualsigma, mg_casualdelta
+# Classic Competitive (Default)		0			1			0				0			mg_active, mg_reserves, mg_hostage, mg_de_dust2, ...
+# Classic Competitive (Short Match)	0			1			32				0			mg_active, mg_reserves, mg_hostage, mg_de_dust2, ...
+# Danger Zone						6			0			0				0			mg_dz_blacksite (map: dz_blacksite), mg_dz_sirocco (map: dz_sirocco)
+# Deathmatch (Default)				1			2			0				0			mg_deathmatch
+# Deathmatch (Free For All)			1			2			32				0			mg_deathmatch
+# Deathmatch (Team vs Team)			1			2			4				0			mg_deathmatch
+# Demolition						1			1			0				0			mg_demolition
+# Flying Scoutsman					0			0			0				3			mg_skirmish_flyingscoutsman
+# Hunter-Gatherers					1			2			0				7			mg_skirmish_huntergatherers
+# Retakes							0			0			0				12			mg_skirmish_retakes
+# Stab Stab Zap						0			0			0				1			mg_skirmish_stabstabzap
+# Trigger Discipline				0			0			0				4			mg_skirmish_triggerdiscipline
+# Wingman							0			2			0				0			mg_de_prime, mg_de_blagai, mg_de_vertigo, mg_de_inferno, mg_de_overpass, mg_de_cbble, mg_de_train, mg_de_shortnuke,	mg_de_shortdust, mg_de_lake
 gametype="0"
 gamemode="0"
 gamemodeflags="0"

--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -21,6 +21,8 @@
 # Danger Zone			6			0			mg_dz_blacksite (map: dz_blacksite), mg_dz_sirocco (map: dz_sirocco)
 gametype="0"
 gamemode="0"
+gamemodeflags="0"
+skirmishid="0"
 mapgroup="mg_active"
 ip="0.0.0.0"
 port="27015"
@@ -43,7 +45,7 @@ wscollectionid=""
 wsstartmap=""
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="-game csgo -usercon -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} +sv_setsteamaccount ${gslt} -tickrate ${tickrate} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers_override ${maxplayers} +mapgroup ${mapgroup} +game_type ${gametype} +game_mode ${gamemode} +host_workshop_collection ${wscollectionid} +workshop_start_map ${wsstartmap} -authkey ${wsapikey} -nobreakpad"
+startparameters="-game csgo -usercon -strictportbind -ip ${ip} -port ${port} +clientport ${clientport} +tv_port ${sourcetvport} +sv_setsteamaccount ${gslt} -tickrate ${tickrate} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers_override ${maxplayers} +mapgroup ${mapgroup} +game_type ${gametype} +game_mode ${gamemode} +sv_game_mode_flags ${gamemodeflags} +sv_skirmish_id ${skirmishid} +host_workshop_collection ${wscollectionid} +workshop_start_map ${wsstartmap} -authkey ${wsapikey} -nobreakpad"
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
# Description
This PR adds the `sv_skirmish_id` and `sv_game_mode_flags` cvars required by newer game modes to csgoserver's LGSM config, which enables users to select all available game modes.

Closes #4004 

## Type of change

-   [ ] Bug fix (a change which fixes an issue).
-   [X] New feature (change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [X] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [X] This pull request links to an issue.
-   [X] This pull request uses the `develop` branch as its base.
-   [X] This pull request Subject follows the Conventional Commits standard.
-   [X] This code follows the style guidelines of this project.
-   [X] I have performed a self-review of my code.
-   [X] I have checked that this code is commented where required.
-   [X] I have provided a detailed with enough description of this PR.
-   [X] I have checked If documentation needs updating.

## Documentation

- [x] The Counter-Strike: Global Offensive page in LinuxGSM-Docs needs updating

Related LinuxGSM-Docs PR: GameServerManagers/LinuxGSM-Docs#87