### PR TITLE
Update _default.cfg

### DIFF
--- a/lgsm/config-default/config-lgsm/rustserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rustserver/_default.cfg
@@ -11,7 +11,8 @@
 ## Predefined Parameters | https://docs.linuxgsm.com/configuration/start-parameters
 ip="0.0.0.0"
 port="28015"
-rconport="28016"
+queryport="28016"
+rconport="28017"
 appport=28082
 rconpassword="CHANGE_ME"
 rconweb="1" # Value is: 1 for the Facepunch web panel, Rustadmin desktop and Rustadmin Online; 0 for RCON tools like Rusty.
@@ -27,7 +28,7 @@ saveinterval="300" # Auto-save in seconds.
 tickrate="30" # default: 30, range: 15-100.
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="-batchmode +app.listenip ${ip} +app.port ${appport} +server.ip ${ip} +server.port ${port} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${selfname}\" +server.gamemode ${gamemode} +server.level \"${serverlevel}\" +server.seed ${seed} +server.salt ${salt} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile"
+startparameters="-batchmode +app.listenip ${ip} +app.port ${appport} +server.ip ${ip} +server.port ${port} +server.queryport ${queryport} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${selfname}\" +server.gamemode ${gamemode} +server.level \"${serverlevel}\" +server.seed ${seed} +server.salt ${salt} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile"
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
INFO

Server owners: update query ports!
As mentioned above, server owners need to define a dedicated query port and game port with this update. Failure to do so will result in players potentially not being able to see or connect to your server. These can no longer share the same port: server.port
server.queryport

Example of a good config:
server.port 28015
server.queryport 28016

OR 

server.port 28016
server.queryport 28015

Example of a bad config:
server.port 28015
server.queryport 28015

By default, if server.queryport is not set, the server will use the port above the game port as the query port. The queryport and the rcon port should be able to share the same port.

# Description

Please include a summary of the change and which issues are fixed.

Fixes #[issue]

## Type of change

-   [ ] Bug fix (a change which fixes an issue).
-   [ ] New feature (change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [ ] This pull request links to an issue.
-   [ ] This pull request uses the `develop` branch as its base.
-   [ ] This pull request Subject follows the Conventional Commits standard.
-   [ ] This code follows the style guidelines of this project.
-   [ ] I have performed a self-review of my code.
-   [ ] I have checked that this code is commented where required.
-   [ ] I have provided a detailed with enough description of this PR.
-   [ ] I have checked If documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
