### PR TITLE
fix(details): port output with whitespaces fails silently

### DIFF
--- a/lgsm/functions/info_messages.sh
+++ b/lgsm/functions/info_messages.sh
@@ -773,7 +773,7 @@ fn_port() {
 		portname="${1}"
 		porttype="${2}"
 		portprotocol="${3}"
-		echo -e "${portname}\t${!porttype}\t${portprotocol}\t$(echo "${ssinfo}" | grep ${portprotocol} | grep ${!porttype} | wc -l)"
+		echo -e "${portname}\t${!porttype}\t${portprotocol}\t$(echo "${ssinfo}" | grep "${portprotocol}" | grep -c "${!porttype}")"
 	fi
 }
 


### PR DESCRIPTION
break down of: https://github.com/GameServerManagers/LinuxGSM/pull/3836

if referenced queryport / voiceport is "NOT SET" grep would look for NOT in the file SET and silently fail