### PR TITLE
fix(gamedig): default exitcode & var name

### DIFF
--- a/lgsm/functions/query_gamedig.sh
+++ b/lgsm/functions/query_gamedig.sh
@@ -7,7 +7,7 @@
 # https://github.com/sonicsnes/node-gamedig
 
 functionselfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
-
+querystatus="2"
 # Check if gamedig and jq are installed.
 if [ "$(command -v gamedig 2> /dev/null)" ] && [ "$(command -v jq 2> /dev/null)" ]; then
 
@@ -81,7 +81,7 @@ if [ "$(command -v gamedig 2> /dev/null)" ] && [ "$(command -v jq 2> /dev/null)"
 
 		# server version.
 		if [ "${querytype}" == "teamspeak3" ]; then
-			dversion=$(echo "${gamedigraw}" | jq -re '.raw.virtualserver_version')
+			gdversion=$(echo "${gamedigraw}" | jq -re '.raw.virtualserver_version')
 		else
 			gdversion=$(echo "${gamedigraw}" | jq -re '.raw.version')
 		fi


### PR DESCRIPTION
break down of: https://github.com/GameServerManagers/LinuxGSM/pull/3836

should always provide "querystatus" and in particular on fail != 0 for monitor command & a typo in a variable name