### PR TITLE
feat(pzserver): Add option to configure server memory usage

### DIFF
--- a/lgsm/config-default/config-lgsm/pzserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pzserver/_default.cfg
@@ -10,10 +10,11 @@
 
 ## Predefined Parameters | https://docs.linuxgsm.com/configuration/start-parameters
 ip="0.0.0.0"
+javaram="8192" # -Xmx$8192M
 adminpassword="CHANGE_ME"
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="--ip ${ip} -adminpassword \"${adminpassword}\" -servername ${selfname}"
+startparameters="--ip ${ip} -adminpassword \"${adminpassword}\" -servername ${selfname} -Xmx${javaram}M"
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
# Description

Add option to configure project zomboïd server memory usage.
Avoid modifying server configuration files and allow using different settings per instances

I'm not found of configuring gigabytes with megabytes values and would like to refactore javaram to also take the unit (as in `javaram="8G"`) and just do `-Xmx${javaram}` if that is ok with you I'll update the PR to also include that.
I've rapidly checked and javaram is only use to display java version in details if set. Nothing seems bound to a megabyte only usage (except perhaps old java versions ?)

Fixes #3056

## Type of change

-   [ ] Bug fix (a change which fixes an issue).
-   [x] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
