### PR TITLE
python version change for rhel-9 & centos-9

### DIFF
--- a/lgsm/data/almalinux-9.csv
+++ b/lgsm/data/almalinux-9.csv
@@ -1,4 +1,4 @@
-all,bc,binutils,bzip2,cpio,curl,epel-release,file,glibc.i686,gzip,hostname,jq,libstdc++,libstdc++.i686,nmap-ncat,python36,tar,tmux,unzip,util-linux,wget,xz
+all,bc,binutils,bzip2,cpio,curl,epel-release,file,glibc.i686,gzip,hostname,jq,libstdc++,libstdc++.i686,nmap-ncat,python3,tar,tmux,unzip,util-linux,wget,xz
 steamcmd,glibc.i686,libstdc++.i686
 ac
 ahl

--- a/lgsm/data/centos-9.csv
+++ b/lgsm/data/centos-9.csv
@@ -1,4 +1,4 @@
-all,bc,binutils,bzip2,cpio,curl,epel-release,file,glibc.i686,gzip,hostname,jq,libstdc++,libstdc++.i686,nmap-ncat,python36,tar,tmux,unzip,util-linux,wget,xz
+all,bc,binutils,bzip2,cpio,curl,epel-release,file,glibc.i686,gzip,hostname,jq,libstdc++,libstdc++.i686,nmap-ncat,python3,tar,tmux,unzip,util-linux,wget,xz
 steamcmd,glibc.i686,libstdc++.i686
 ac
 ahl

--- a/lgsm/data/rhel-9.csv
+++ b/lgsm/data/rhel-9.csv
@@ -1,4 +1,4 @@
-all,bc,binutils,bzip2,cpio,curl,epel-release,file,glibc.i686,gzip,hostname,jq,libstdc++,libstdc++.i686,nmap-ncat,python36,tar,tmux,unzip,util-linux,wget,xz
+all,bc,binutils,bzip2,cpio,curl,epel-release,file,glibc.i686,gzip,hostname,jq,libstdc++,libstdc++.i686,nmap-ncat,python3,tar,tmux,unzip,util-linux,wget,xz
 steamcmd,glibc.i686,libstdc++.i686
 ac
 ahl

--- a/lgsm/data/rocky-9.csv
+++ b/lgsm/data/rocky-9.csv
@@ -1,4 +1,4 @@
-all,bc,binutils,bzip2,cpio,curl,epel-release,file,glibc.i686,gzip,hostname,jq,libstdc++,libstdc++.i686,nmap-ncat,python36,tar,tmux,unzip,util-linux,wget,xz
+all,bc,binutils,bzip2,cpio,curl,epel-release,file,glibc.i686,gzip,hostname,jq,libstdc++,libstdc++.i686,nmap-ncat,python3,tar,tmux,unzip,util-linux,wget,xz
 steamcmd,glibc.i686,libstdc++.i686
 ac
 ahl


### PR DESCRIPTION
# Description

- python36 is no longer available in the repo list for rhel-9 & centos-9
- not possible to use "dnf install python36" or "yum install python36", manually compiling from source or using pyenv is only way to install python36 (from testing)
- switching from python36 to python3 in lgsm data files works for latest rhel-9 (redhat9) dev build
- tested with csgoserver, running without issues after running commands:
```
./linuxgsm.sh install
<selected csgoserver from gui>
./csgoserver install
./csgoserver start
./csgoserver console
```

Fixes [#4202] 

## Type of change

-   [X] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [X] This pull request links to an issue.
-   [X] This pull request uses the `develop` branch as its base.
-   [X] This pull request subject follows the Conventional Commits standard.
-   [X] This code follows the style guidelines of this project.
-   [X] I have performed a self-review of my code.
-   [X] I have checked that this code is commented where required.
-   [X] I have provided a detailed enough description of this PR.
-   [X] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
