### PR TITLE
fix(armar): fix parsing new a2s config

### DIFF
--- a/lgsm/functions/info_game.sh
+++ b/lgsm/functions/info_game.sh
@@ -97,8 +97,8 @@ fn_info_game_armar() {
 	if [ ! -f "${servercfgfullpath}" ]; then
 		adminpassword="${unavailable}"
 		maxplayers="${zero}"
-		port=${port:-"0"}
-		queryport=
+		port="${zero}"
+		queryport="${zero}"
 		servername="${unavailable}"
 		serverpassword="${unavailable}"
 	else
@@ -107,7 +107,7 @@ fn_info_game_armar() {
 		configip=$(jq -r '.bindAddress' "${servercfgfullpath}")
 		maxplayers=$(jq -r '.game.maxPlayers' "${servercfgfullpath}")
 		port=$(jq -r '.bindPort' "${servercfgfullpath}")
-		queryport=$(jq -r '.steamQueryPort' "${servercfgfullpath}")
+		queryport=$(jq -r '.a2s.port' "${servercfgfullpath}")
 		servername=$(jq -r '.game.name' "${servercfgfullpath}")
 		serverpassword=$(jq -r '.game.password' "${servercfgfullpath}")
 

--- a/lgsm/modules/info_game.sh
+++ b/lgsm/modules/info_game.sh
@@ -876,7 +876,7 @@ fn_info_game_armar() {
 		fn_info_game_json "configip" ".bindAddress"
 		fn_info_game_json "maxplayers" ".game.maxPlayers"
 		fn_info_game_json "port" ".bindPort"
-		fn_info_game_json "queryport" ".steamQueryPort"
+		fn_info_game_json "queryport" ".a2s.port"
 		fn_info_game_json "servername" ".game.name"
 		fn_info_game_json "serverpassword" ".game.password"
 	fi


### PR DESCRIPTION
# Description

Config variables `a2sQueryEnabled` and `steamQueryPort` was removed in 0.9.9.31.
This fixed config parser for new a2s entities.
This is continuation of https://github.com/GameServerManagers/LinuxGSM/pull/4240
Both https://github.com/GameServerManagers/LinuxGSM/pull/4240, and this one, use https://github.com/GameServerManagers/Game-Server-Configs/pull/135 changes in Config repo and should be released in parallel.

Fixes #4239

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.
