### PR TITLE
fix(arma3server): remove quotes from around mod list in Arma3 server command line

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Issue Labeler
-        uses: github/issue-labeler@v3.1
+        uses: github/issue-labeler@v3.2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/labeler.yml

--- a/lgsm/config-default/config-lgsm/arma3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arma3server/_default.cfg
@@ -32,7 +32,7 @@ servermods=""
 bepath=""
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="-ip=${ip} -port=${port} -cfg=${networkcfgfullpath} -config=${servercfgfullpath} -mod='${mods}' -servermod=${servermods} -bepath=${bepath} -autoinit -loadmissiontomemory"
+startparameters="-ip=${ip} -port=${port} -cfg=${networkcfgfullpath} -config=${servercfgfullpath} -mod=${mods} -servermod=${servermods} -bepath=${bepath} -autoinit -loadmissiontomemory"
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
# Description

This removes the quotes around the mod list as it appears in the command line parameters.  This was breaking mod loading.

This reverts a change made by PR #3845, so I expect this may need discussion.

Fixes #4021

## Type of change

-   Bug fix (a change which fixes an issue).

