### PR TITLE
feat: Migrate stats to Google GA-4

### DIFF
--- a/lgsm/modules/info_distro.sh
+++ b/lgsm/modules/info_distro.sh
@@ -73,7 +73,12 @@ for distro_info in "${distro_info_array[@]}"; do
 	fi
 done
 
-# some RHEL based distros use 8.4 instead of just 8.
+# Get virtual environment
+if [ "$(command -v systemd-detect-virt 2> /dev/null)" ]; then
+	virtualenvironment="$(systemd-detect-virt)"
+fi
+
+# Some RHEL based distros use 8.4 instead of just 8.
 if [[ "${distroidlike}" == *"rhel"* ]] || [ "${distroid}" == "rhel" ]; then
 	distroversioncsv="${distroversionrh}"
 else

--- a/lgsm/modules/info_game.sh
+++ b/lgsm/modules/info_game.sh
@@ -2397,20 +2397,6 @@ else
 	extip="$(cat "${tmpdir}/extip.txt")"
 fi
 
-# Country code of external IP address
-if [ ! -f "${tmpdir}/countrycode.txt" ]; then
-	countrycode="$(curl --connect-timeout 10 -s https://ipapi.co/country 2> /dev/null)"
-	exitcode=$?
-	# if curl passes add extip to externalip.txt
-	if [ "${exitcode}" == "0" ]; then
-		echo "${countrycode}" > "${tmpdir}/countrycode.txt"
-	else
-		echo "Unable to get external IP address"
-	fi
-else
-	countrycode="$(cat "${tmpdir}/countrycode.txt")"
-fi
-
 # Alert IP address
 if [ "${displayip}" ]; then
 	alertip="${displayip}"

--- a/lgsm/modules/info_game.sh
+++ b/lgsm/modules/info_game.sh
@@ -2397,6 +2397,20 @@ else
 	extip="$(cat "${tmpdir}/extip.txt")"
 fi
 
+# Country code of external IP address
+if [ ! -f "${tmpdir}/countrycode.txt" ]; then
+	countrycode="$(curl --connect-timeout 10 -s https://ipapi.co/country 2> /dev/null)"
+	exitcode=$?
+	# if curl passes add extip to externalip.txt
+	if [ "${exitcode}" == "0" ]; then
+		echo "${countrycode}" > "${tmpdir}/countrycode.txt"
+	else
+		echo "Unable to get external IP address"
+	fi
+else
+	countrycode="$(cat "${tmpdir}/countrycode.txt")"
+fi
+
 # Alert IP address
 if [ "${displayip}" ]; then
 	alertip="${displayip}"

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -68,7 +68,7 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 		{
 		\"name\": \"LinuxGSM\",
 		\"params\": {
-			\"countryId\":\"${countrycode}\"
+			\"countryId\":\"${countrycode}\",
 			\"cpuusedmhzroundup\": \"${cpuusedmhzroundup}MHz\",
 			\"diskused\": \"${serverfilesdu}\",
 			\"distro\": \"${distroname}\",
@@ -83,7 +83,7 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 			\"uuidhardware\": \"${uuidhardware}\",
 			\"uuidinstall\": \"${uuidinstall}\",
 			\"uuidinstance\": \"${uuidinstance}\",
-			\"version\": \"${version}\",
+			\"version\": \"${version}\"
 			}
 		}
 	]

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -82,7 +82,8 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 			\"uuidhardware\": \"${uuidhardware}\",
 			\"uuidinstall\": \"${uuidinstall}\",
 			\"uuidinstance\": \"${uuidinstance}\",
-			\"version\": \"${version}\"
+			\"version\": \"${version}\",
+			\"virtualenvironment\": \"${virtualenvironment}\"
 			}
 		}
 	]
@@ -108,7 +109,8 @@ curl -i -X POST https://stats.linuxgsm.com/api/event \
 				\"servercpufreq\": \"${cpufreqency} x${cpucores}\",
 				\"serverdisk\": \"${totalspace}\",
 				\"serverram\": \"${physmemtotal}\",
-				\"version\": \"${version}\"
+				\"version\": \"${version}\",
+				\"virtualenvironment\": \"${virtualenvironment}\"
 			}"
 
 ## Alert Stats.

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -61,7 +61,6 @@ memusedroundup="$(((memused + 99) / 100 * 100))"
 # Install Property - UA-165287622-2
 # Hardware Property - UA-165287622-3
 
-
 curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMWt4_vHi6ZpUw&measurement_id=G-0CR8V7EMT5" -H "Content-Type: application/json" -d "
 {
 	\"client_id\": \"${uuidinstance}\",
@@ -89,6 +88,28 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 	]
 }"
 
+curl -i -X POST https://stats.linuxgsm.com/api/event \
+  -H 'X-Forwarded-For: 127.0.0.1' \
+  -H 'Content-Type: application/json' \
+  --data "{\"name\":\"linuxgsm\",
+			\"url\":\"https://stats.linuxgsm.com\",
+			\"domain\":\"stats.linuxgsm.com\",
+			\"cpuusedmhzroundup\": \"${cpuusedmhzroundup}MHz\",
+			\"memusedroundup\": \"${memusedroundup}MB\",
+			\"serverfilesdu\": \"${serverfilesdu}\",
+			\"uuidhardware\": \"${uuidhardware}\",
+			\"uuidinstall\": \"${uuidinstall}\",
+			\"uuidinstance\": \"${uuidinstance}\",
+			\"diskused\": \"${serverfilesdu}\",
+			\"distro\": \"${distroname}\",
+			\"game\": \"${gamename}\",
+			\"ramused\": \"${memusedroundup}MB\",
+			\"servercpu\": \"${cpumodel} ${cpucores} cores\",
+			\"servercpufreq\": \"${cpufreqency} x${cpucores}\",
+			\"serverdisk\": \"${totalspace}\",
+			\"serverram\": \"${physmemtotal}\",
+			\"version\": \"${version}\"
+			}"
 ## Alert Stats.
 if [ "${discordalert}" == "on" ]; then
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Discord" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -84,6 +84,16 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 			\"uuidinstance\": \"${uuidinstance}\",
 			\"version\": \"${version}\",
 			\"virtualenvironment\": \"${virtualenvironment}\"
+			\"discordalert\": \"${discordalert}\",
+			\"emailalert\": \"${emailalert}\",
+			\"gotifyalert\": \"${gotifyalert}\",
+			\"iftttalert\": \"${iftttalert}\",
+			\"mailgunalert\": \"${mailgunalert}\",
+			\"pushbulletalert\": \"${pushbulletalert}\",
+			\"pushoveralert\": \"${pushoveralert}\",
+			\"rocketchatalert\": \"${rocketchatalert}\",
+			\"slackalert\": \"${slackalert}\",
+			\"telegramalert\": \"${telegramalert}\"
 			}
 		}
 	]

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -89,7 +89,6 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 }"
 
 curl -i -X POST https://stats.linuxgsm.com/api/event \
-  -H 'X-Forwarded-For: 127.0.0.1' \
   -H 'Content-Type: application/json' \
   --data "{\"name\":\"linuxgsm\",
 			\"url\":\"https://stats.linuxgsm.com\",

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -68,7 +68,7 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 		{
 		\"name\": \"LinuxGSM\",
 		\"params\": {
-			\"country\":\"${countrycode}\"
+			\"countryId\":\"${countrycode}\"
 			\"cpuusedmhzroundup\": \"${cpuusedmhzroundup}MHz\",
 			\"diskused\": \"${serverfilesdu}\",
 			\"distro\": \"${distroname}\",

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -56,46 +56,16 @@ cpuusedmhzroundup="$(((cpuusedmhz + 99) / 100 * 100))"
 # nearest 100MB
 memusedroundup="$(((memused + 99) / 100 * 100))"
 
+apisecret="A-OzP02TSMWt4_vHi6ZpUw"
+measurementid="G-0CR8V7EMT5"
+
 # Sending stats to Google Analytics GA4
 payload="{
 	\"client_id\": \"${uuidinstance}\",
 	\"events\": [
 		{
 		\"name\": \"LinuxGSM\",
-		\"params\": {"
-
-if [ "${discordalert}" == "on" ]; then
-	payload="${payload} \"alert\": \"discord\","
-fi
-if [ "${emailalert}" == "on" ]; then
-	payload="${payload} \"alert\": \"email\","
-fi
-if [ "${gotifyalert}" == "on" ]; then
-	payload="${payload}, \"alert\": \"gotify\","
-fi
-if [ "${iftttalert}" == "on" ]; then
-	payload="${payload}, \"alert\": \"ifttt\","
-fi
-if [ "${mailgunalert}" == "on" ]; then
-	payload="${payload} \"alert\": \"mailgun\","
-fi
-if [ "${pushbulletalert}" == "on" ]; then
-	payload="${payload} \"alert\": \"pushbullet\","
-fi
-if [ "${pushoveralert}" == "on" ]; then
-	payload="${payload} \"alert\": \"pushover\","
-fi
-if [ "${rocketchatalert}" == "on" ]; then
-	payload="${payload} \"alert\": \"rocketchat\","
-fi
-if [ "${slackalert}" == "on" ]; then
-	payload="${payload} \"alert\": \"slack\","
-fi
-if [ "${telegramalert}" == "on" ]; then
-	payload="${payload} \"alert\": \"telegram\","
-fi
-
-payload="${payload}
+		\"params\": {
 			\"cpuusedmhzroundup\": \"${cpuusedmhzroundup}MHz\",
 			\"diskused\": \"${serverfilesdu}\",
 			\"distro\": \"${distroname}\",
@@ -117,7 +87,72 @@ payload="${payload}
 	]
 }"
 
+fn_alert_payload(){
+alertpayload="{
+	\"client_id\": \"${uuidinstance}\",
+	\"events\": [
+		{
+		\"name\": \"LinuxGSM\",
+		\"params\": {
+			\"alert\": \"${alerttype}\"
+			}
+		}
+	]
+}"
+}
+
 curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMWt4_vHi6ZpUw&measurement_id=G-0CR8V7EMT5" -H "Content-Type: application/json" -d "${payload}"
+
+if [ "${discordalert}" == "on" ]; then
+	alerttype="discord"
+	fn_alert_payload
+	curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=${apisecret}&measurement_id=${measurementid}" -H "Content-Type: application/json" -d "${alertpayload}"
+fi
+if [ "${emailalert}" == "on" ]; then
+	alerttype="email"
+	fn_alert_payload
+	curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=${apisecret}&measurement_id=${measurementid}" -H "Content-Type: application/json" -d "${alertpayload}"
+fi
+if [ "${gotifyalert}" == "on" ]; then
+	alerttype="gotify"
+	fn_alert_payload
+	curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=${apisecret}&measurement_id=${measurementid}" -H "Content-Type: application/json" -d "${alertpayload}"
+fi
+if [ "${iftttalert}" == "on" ]; then
+	alerttype="ifttt"
+	fn_alert_payload
+	curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=${apisecret}&measurement_id=${measurementid}" -H "Content-Type: application/json" -d "${alertpayload}"
+fi
+if [ "${mailgunalert}" == "on" ]; then
+	alerttype="mailgun"
+	fn_alert_payload
+	curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=${apisecret}&measurement_id=${measurementid}" -H "Content-Type: application/json" -d "${alertpayload}"
+fi
+if [ "${pushbulletalert}" == "on" ]; then
+	alerttype="pushbullet"
+	fn_alert_payload
+	curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=${apisecret}&measurement_id=${measurementid}" -H "Content-Type: application/json" -d "${alertpayload}"
+fi
+if [ "${pushoveralert}" == "on" ]; then
+	alerttype="pushover"
+	fn_alert_payload
+	curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=${apisecret}&measurement_id=${measurementid}" -H "Content-Type: application/json" -d "${alertpayload}"
+fi
+if [ "${rocketchatalert}" == "on" ]; then
+	alerttype="rocketchat"
+	fn_alert_payload
+	curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=${apisecret}&measurement_id=${measurementid}" -H "Content-Type: application/json" -d "${alertpayload}"
+fi
+if [ "${slackalert}" == "on" ]; then
+	alerttype="slack"
+	fn_alert_payload
+	curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=${apisecret}&measurement_id=${measurementid}" -H "Content-Type: application/json" -d "${alertpayload}"
+fi
+if [ "${telegramalert}" == "on" ]; then
+	alerttype="telegram"
+	fn_alert_payload
+	curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=${apisecret}&measurement_id=${measurementid}" -H "Content-Type: application/json" -d "${alertpayload}"
+fi
 
 fn_script_log_info "Send LinuxGSM stats"
 fn_script_log_info "* uuid-${selfname}: ${uuidinstance}"

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -66,7 +66,41 @@ payload="{
 	\"events\": [
 		{
 		\"name\": \"LinuxGSM\",
-		\"params\": {
+		\"params\": {"
+
+if [ "${discordalert}" == "on" ]; then
+	payload="${payload} \"discordalert\": \"${discordalert}\","
+fi
+if [ "${emailalert}" == "on" ]; then
+	payload="${payload} \"emailalert\": \"${emailalert}\","
+fi
+if [ "${gotifyalert}" == "on" ]; then
+	payload="${payload}, \"gotifyalert\": \"${gotifyalert}\","
+fi
+if [ "${iftttalert}" == "on" ]; then
+	payload="${payload}, \"iftttalert\": \"${iftttalert}\","
+fi
+if [ "${mailgunalert}" == "on" ]; then
+	payload="${payload} \"mailgunalert\": \"${mailgunalert}\","
+fi
+if [ "${pushbulletalert}" == "on" ]; then
+	payload="${payload} \"pushbulletalert\": \"${pushbulletalert}\","
+fi
+if [ "${pushoveralert}" == "on" ]; then
+	payload="${payload} \"pushoveralert\": \"${pushoveralert}\","
+fi
+if [ "${rocketchatalert}" == "on" ]; then
+	payload="${payload} \"rocketchatalert\": \"${rocketchatalert}\","
+fi
+if [ "${slackalert}" == "on" ]; then
+	payload="${payload} \"slackalert\": \"${slackalert}\","
+fi
+if [ "${telegramalert}" == "on" ]; then
+	payload="${payload} \"telegramalert\": \"${telegramalert}\","
+fi
+
+
+payload="${payload}
 			\"cpuusedmhzroundup\": \"${cpuusedmhzroundup}MHz\",
 			\"diskused\": \"${serverfilesdu}\",
 			\"distro\": \"${distroname}\",
@@ -82,40 +116,7 @@ payload="{
 			\"uuidinstall\": \"${uuidinstall}\",
 			\"uuidinstance\": \"${uuidinstance}\",
 			\"version\": \"${version}\",
-			\"virtualenvironment\": \"${virtualenvironment}\","
-
-if [ "${discordalert}" == "on" ]; then
-	payload="${payload}, \"discordalert\": \"${discordalert}\""
-fi
-if [ "${emailalert}" == "on" ]; then
-	payload="${payload}, \"emailalert\": \"${emailalert}\""
-fi
-if [ "${gotifyalert}" == "on" ]; then
-	payload="${payload}, \"gotifyalert\": \"${gotifyalert}\""
-fi
-if [ "${iftttalert}" == "on" ]; then
-	payload="${payload}, \"iftttalert\": \"${iftttalert}\""
-fi
-if [ "${mailgunalert}" == "on" ]; then
-	payload="${payload}, \"mailgunalert\": \"${mailgunalert}\""
-fi
-if [ "${pushbulletalert}" == "on" ]; then
-	payload="${payload}, \"pushbulletalert\": \"${pushbulletalert}\""
-fi
-if [ "${pushoveralert}" == "on" ]; then
-	payload="${payload}, \"pushoveralert\": \"${pushoveralert}\""
-fi
-if [ "${rocketchatalert}" == "on" ]; then
-	payload="${payload}, \"rocketchatalert\": \"${rocketchatalert}\""
-fi
-if [ "${slackalert}" == "on" ]; then
-	payload="${payload}, \"slackalert\": \"${slackalert}\""
-fi
-if [ "${telegramalert}" == "on" ]; then
-	payload="${payload}, \"telegramalert\": \"${telegramalert}\""
-fi
-
-payload="${payload}
+			\"virtualenvironment\": \"${virtualenvironment}\"
 			}
 		}
 	]

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -68,21 +68,22 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 		{
 		\"name\": \"LinuxGSM\",
 		\"params\": {
+			\"country\":\"${countrycode}\"
 			\"cpuusedmhzroundup\": \"${cpuusedmhzroundup}MHz\",
-			\"memusedroundup\": \"${memusedroundup}MB\",
-			\"serverfilesdu\": \"${serverfilesdu}\",
-			\"uuidhardware\": \"${uuidhardware}\",
-			\"uuidinstall\": \"${uuidinstall}\",
-			\"uuidinstance\": \"${uuidinstance}\",
 			\"diskused\": \"${serverfilesdu}\",
 			\"distro\": \"${distroname}\",
 			\"game\": \"${gamename}\",
+			\"memusedroundup\": \"${memusedroundup}MB\",
 			\"ramused\": \"${memusedroundup}MB\",
 			\"servercpu\": \"${cpumodel} ${cpucores} cores\",
 			\"servercpufreq\": \"${cpufreqency} x${cpucores}\",
 			\"serverdisk\": \"${totalspace}\",
+			\"serverfilesdu\": \"${serverfilesdu}\",
 			\"serverram\": \"${physmemtotal}\",
-			\"version\": \"${version}\"
+			\"uuidhardware\": \"${uuidhardware}\",
+			\"uuidinstall\": \"${uuidinstall}\",
+			\"uuidinstance\": \"${uuidinstance}\",
+			\"version\": \"${version}\",
 			}
 		}
 	]

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -110,37 +110,18 @@ curl -X POST https://stats.linuxgsm.com/api/event \
 				\"serverdisk\": \"${totalspace}\",
 				\"serverram\": \"${physmemtotal}\",
 				\"version\": \"${version}\",
-				\"virtualenvironment\": \"${virtualenvironment}\"
+				\"virtualenvironment\": \"${virtualenvironment}\",
+				\"discordalert\": \"${discordalert}\",
+				\"emailalert\": \"${emailalert}\",
+				\"gotifyalert\": \"${gotifyalert}\",
+				\"iftttalert\": \"${iftttalert}\",
+				\"mailgunalert\": \"${mailgunalert}\",
+				\"pushbulletalert\": \"${pushbulletalert}\",
+				\"pushoveralert\": \"${pushoveralert}\",
+				\"rocketchatalert\": \"${rocketchatalert}\",
+				\"slackalert\": \"${slackalert}\",
+				\"telegramalert\": \"${telegramalert}\"
 			}"
-
-## Alert Stats.
-if [ "${discordalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Discord" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
-if [ "${emailalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Email" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
-if [ "${iftttalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=IFTTT" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
-if [ "${mailgunalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Mailgun" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
-if [ "${pushbulletalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Pushbullet" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
-if [ "${pushoveralert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Pushover" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
-if [ "${rocketchatalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Rocket Chat" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
-if [ "${slackalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Slack" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
-if [ "${telegramalert}" == "on" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Telegram" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
 
 fn_script_log_info "Send LinuxGSM stats"
 fn_script_log_info "* uuid-${selfname}: ${uuidinstance}"
@@ -155,3 +136,6 @@ fn_script_log_info "* Server CPU Model: ${cpumodel}"
 fn_script_log_info "* Server CPU Frequency: ${cpufreqency}"
 fn_script_log_info "* Server RAM: ${physmemtotal}"
 fn_script_log_info "* Server Disk: ${totalspace}"
+fn_script_log_info "* Virtual Environment: ${virtualenvironment}"
+fn_script_log_info "* LinuxGSM Version: ${version}"
+fn_script_log_info "* Enabled Alerts"

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -56,11 +56,7 @@ cpuusedmhzroundup="$(((cpuusedmhz + 99) / 100 * 100))"
 # nearest 100MB
 memusedroundup="$(((memused + 99) / 100 * 100))"
 
-# Spliting the metrics in to 3 propertys allows more accurate metrics on numbers of invidual instances, installs and hardware.
-# Instance Property - UA-165287622-1
-# Install Property - UA-165287622-2
-# Hardware Property - UA-165287622-3
-
+# Sending stats to Google Analytics GA4
 payload="{
 	\"client_id\": \"${uuidinstance}\",
 	\"events\": [
@@ -99,7 +95,6 @@ if [ "${telegramalert}" == "on" ]; then
 	payload="${payload} \"alert\": \"telegram\","
 fi
 
-
 payload="${payload}
 			\"cpuusedmhzroundup\": \"${cpuusedmhzroundup}MHz\",
 			\"diskused\": \"${serverfilesdu}\",
@@ -123,40 +118,6 @@ payload="${payload}
 }"
 
 curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMWt4_vHi6ZpUw&measurement_id=G-0CR8V7EMT5" -H "Content-Type: application/json" -d "${payload}"
-
-curl -X POST https://stats.linuxgsm.com/api/event \
-	-H 'User-Agent: curl' \
-	-H 'Content-Type: application/json' \
-	--data "{\"name\":\"pageview\",
-				\"url\":\"https://stats.linuxgsm.com\",
-				\"domain\":\"stats.linuxgsm.com\",
-				\"cpuusedmhzroundup\": \"${cpuusedmhzroundup}MHz\",
-				\"memusedroundup\": \"${memusedroundup}MB\",
-				\"serverfilesdu\": \"${serverfilesdu}\",
-				\"uuidhardware\": \"${uuidhardware}\",
-				\"uuidinstall\": \"${uuidinstall}\",
-				\"uuidinstance\": \"${uuidinstance}\",
-				\"diskused\": \"${serverfilesdu}\",
-				\"distro\": \"${distroname}\",
-				\"game\": \"${gamename}\",
-				\"ramused\": \"${memusedroundup}MB\",
-				\"servercpu\": \"${cpumodel} ${cpucores} cores\",
-				\"servercpufreq\": \"${cpufreqency} x${cpucores}\",
-				\"serverdisk\": \"${totalspace}\",
-				\"serverram\": \"${physmemtotal}\",
-				\"version\": \"${version}\",
-				\"virtualenvironment\": \"${virtualenvironment}\",
-				\"discordalert\": \"${discordalert}\",
-				\"emailalert\": \"${emailalert}\",
-				\"gotifyalert\": \"${gotifyalert}\",
-				\"iftttalert\": \"${iftttalert}\",
-				\"mailgunalert\": \"${mailgunalert}\",
-				\"pushbulletalert\": \"${pushbulletalert}\",
-				\"pushoveralert\": \"${pushoveralert}\",
-				\"rocketchatalert\": \"${rocketchatalert}\",
-				\"slackalert\": \"${slackalert}\",
-				\"telegramalert\": \"${telegramalert}\"
-			}"
 
 fn_script_log_info "Send LinuxGSM stats"
 fn_script_log_info "* uuid-${selfname}: ${uuidinstance}"

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -69,34 +69,34 @@ payload="{
 		\"params\": {"
 
 if [ "${discordalert}" == "on" ]; then
-	payload="${payload} \"discordalert\": \"${discordalert}\","
+	payload="${payload} \"alert\": \"discord\","
 fi
 if [ "${emailalert}" == "on" ]; then
-	payload="${payload} \"emailalert\": \"${emailalert}\","
+	payload="${payload} \"alert\": \"email\","
 fi
 if [ "${gotifyalert}" == "on" ]; then
-	payload="${payload}, \"gotifyalert\": \"${gotifyalert}\","
+	payload="${payload}, \"alert\": \"gotify\","
 fi
 if [ "${iftttalert}" == "on" ]; then
-	payload="${payload}, \"iftttalert\": \"${iftttalert}\","
+	payload="${payload}, \"alert\": \"ifttt\","
 fi
 if [ "${mailgunalert}" == "on" ]; then
-	payload="${payload} \"mailgunalert\": \"${mailgunalert}\","
+	payload="${payload} \"alert\": \"mailgun\","
 fi
 if [ "${pushbulletalert}" == "on" ]; then
-	payload="${payload} \"pushbulletalert\": \"${pushbulletalert}\","
+	payload="${payload} \"alert\": \"pushbullet\","
 fi
 if [ "${pushoveralert}" == "on" ]; then
-	payload="${payload} \"pushoveralert\": \"${pushoveralert}\","
+	payload="${payload} \"alert\": \"pushover\","
 fi
 if [ "${rocketchatalert}" == "on" ]; then
-	payload="${payload} \"rocketchatalert\": \"${rocketchatalert}\","
+	payload="${payload} \"alert\": \"rocketchat\","
 fi
 if [ "${slackalert}" == "on" ]; then
-	payload="${payload} \"slackalert\": \"${slackalert}\","
+	payload="${payload} \"alert\": \"slack\","
 fi
 if [ "${telegramalert}" == "on" ]; then
-	payload="${payload} \"telegramalert\": \"${telegramalert}\","
+	payload="${payload} \"alert\": \"telegram\","
 fi
 
 

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -89,7 +89,7 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 	]
 }"
 
-curl -i -X POST https://stats.linuxgsm.com/api/event \
+curl -X POST https://stats.linuxgsm.com/api/event \
 	-H 'User-Agent: curl' \
 	-H 'Content-Type: application/json' \
 	--data "{\"name\":\"pageview\",

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -61,8 +61,7 @@ memusedroundup="$(((memused + 99) / 100 * 100))"
 # Install Property - UA-165287622-2
 # Hardware Property - UA-165287622-3
 
-curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMWt4_vHi6ZpUw&measurement_id=G-0CR8V7EMT5" -H "Content-Type: application/json" -d "
-{
+payload="{
 	\"client_id\": \"${uuidinstance}\",
 	\"events\": [
 		{
@@ -83,21 +82,46 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 			\"uuidinstall\": \"${uuidinstall}\",
 			\"uuidinstance\": \"${uuidinstance}\",
 			\"version\": \"${version}\",
-			\"virtualenvironment\": \"${virtualenvironment}\",
-			\"discordalert\": \"${discordalert}\",
-			\"emailalert\": \"${emailalert}\",
-			\"gotifyalert\": \"${gotifyalert}\",
-			\"iftttalert\": \"${iftttalert}\",
-			\"mailgunalert\": \"${mailgunalert}\",
-			\"pushbulletalert\": \"${pushbulletalert}\",
-			\"pushoveralert\": \"${pushoveralert}\",
-			\"rocketchatalert\": \"${rocketchatalert}\",
-			\"slackalert\": \"${slackalert}\",
-			\"telegramalert\": \"${telegramalert}\"
+			\"virtualenvironment\": \"${virtualenvironment}\","
+
+if [ "${discordalert}" == "on" ]; then
+	payload="${payload}, \"discordalert\": \"${discordalert}\""
+fi
+if [ "${emailalert}" == "on" ]; then
+	payload="${payload}, \"emailalert\": \"${emailalert}\""
+fi
+if [ "${gotifyalert}" == "on" ]; then
+	payload="${payload}, \"gotifyalert\": \"${gotifyalert}\""
+fi
+if [ "${iftttalert}" == "on" ]; then
+	payload="${payload}, \"iftttalert\": \"${iftttalert}\""
+fi
+if [ "${mailgunalert}" == "on" ]; then
+	payload="${payload}, \"mailgunalert\": \"${mailgunalert}\""
+fi
+if [ "${pushbulletalert}" == "on" ]; then
+	payload="${payload}, \"pushbulletalert\": \"${pushbulletalert}\""
+fi
+if [ "${pushoveralert}" == "on" ]; then
+	payload="${payload}, \"pushoveralert\": \"${pushoveralert}\""
+fi
+if [ "${rocketchatalert}" == "on" ]; then
+	payload="${payload}, \"rocketchatalert\": \"${rocketchatalert}\""
+fi
+if [ "${slackalert}" == "on" ]; then
+	payload="${payload}, \"slackalert\": \"${slackalert}\""
+fi
+if [ "${telegramalert}" == "on" ]; then
+	payload="${payload}, \"telegramalert\": \"${telegramalert}\""
+fi
+
+payload="${payload}
 			}
 		}
 	]
 }"
+
+curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMWt4_vHi6ZpUw&measurement_id=G-0CR8V7EMT5" -H "Content-Type: application/json" -d "${payload}"
 
 curl -X POST https://stats.linuxgsm.com/api/event \
 	-H 'User-Agent: curl' \

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -68,7 +68,6 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 		{
 		\"name\": \"LinuxGSM\",
 		\"params\": {
-			\"countryId\":\"${countrycode}\",
 			\"cpuusedmhzroundup\": \"${cpuusedmhzroundup}MHz\",
 			\"diskused\": \"${serverfilesdu}\",
 			\"distro\": \"${distroname}\",

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -89,26 +89,28 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 }"
 
 curl -i -X POST https://stats.linuxgsm.com/api/event \
-  -H 'Content-Type: application/json' \
-  --data "{\"name\":\"linuxgsm\",
-			\"url\":\"https://stats.linuxgsm.com\",
-			\"domain\":\"stats.linuxgsm.com\",
-			\"cpuusedmhzroundup\": \"${cpuusedmhzroundup}MHz\",
-			\"memusedroundup\": \"${memusedroundup}MB\",
-			\"serverfilesdu\": \"${serverfilesdu}\",
-			\"uuidhardware\": \"${uuidhardware}\",
-			\"uuidinstall\": \"${uuidinstall}\",
-			\"uuidinstance\": \"${uuidinstance}\",
-			\"diskused\": \"${serverfilesdu}\",
-			\"distro\": \"${distroname}\",
-			\"game\": \"${gamename}\",
-			\"ramused\": \"${memusedroundup}MB\",
-			\"servercpu\": \"${cpumodel} ${cpucores} cores\",
-			\"servercpufreq\": \"${cpufreqency} x${cpucores}\",
-			\"serverdisk\": \"${totalspace}\",
-			\"serverram\": \"${physmemtotal}\",
-			\"version\": \"${version}\"
+	-H 'User-Agent: curl' \
+	-H 'Content-Type: application/json' \
+	--data "{\"name\":\"linuxgsm\",
+				\"url\":\"https://stats.linuxgsm.com\",
+				\"domain\":\"stats.linuxgsm.com\",
+				\"cpuusedmhzroundup\": \"${cpuusedmhzroundup}MHz\",
+				\"memusedroundup\": \"${memusedroundup}MB\",
+				\"serverfilesdu\": \"${serverfilesdu}\",
+				\"uuidhardware\": \"${uuidhardware}\",
+				\"uuidinstall\": \"${uuidinstall}\",
+				\"uuidinstance\": \"${uuidinstance}\",
+				\"diskused\": \"${serverfilesdu}\",
+				\"distro\": \"${distroname}\",
+				\"game\": \"${gamename}\",
+				\"ramused\": \"${memusedroundup}MB\",
+				\"servercpu\": \"${cpumodel} ${cpucores} cores\",
+				\"servercpufreq\": \"${cpufreqency} x${cpucores}\",
+				\"serverdisk\": \"${totalspace}\",
+				\"serverram\": \"${physmemtotal}\",
+				\"version\": \"${version}\"
 			}"
+
 ## Alert Stats.
 if [ "${discordalert}" == "on" ]; then
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Discord" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -61,68 +61,33 @@ memusedroundup="$(((memused + 99) / 100 * 100))"
 # Install Property - UA-165287622-2
 # Hardware Property - UA-165287622-3
 
-## Distro.
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=distro" -d "ea=${distroname}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=distro" -d "ea=${distroname}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=distro" -d "ea=${distroname}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 
-## Game Server Name.
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=game" -d "ea=${gamename}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=game" -d "ea=${gamename}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=game" -d "ea=${gamename}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-
-## LinuxGSM Version.
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=version" -d "ea=${version}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=version" -d "ea=${version}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=version" -d "ea=${version}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-
-## CPU usage of a game server.
-if [ -n "${cpuusedmhzroundup}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=cpuused" -d "ea=${cpuusedmhzroundup}MHz" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=cpuused" -d "ea=${cpuusedmhzroundup}MHz" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=cpuused" -d "ea=${cpuusedmhzroundup}MHz" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
-## Ram usage of a game server.
-if [ -n "${memusedroundup}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=ramused" -d "ea=${memusedroundup}MB" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=ramused" -d "ea=${memusedroundup}MB" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=ramused" -d "ea=${memusedroundup}MB" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
-## Disk usage of a game server.
-if [ -n "${serverfilesdu}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=diskused" -d "ea=${serverfilesdu}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=diskused" -d "ea=${serverfilesdu}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=diskused" -d "ea=${serverfilesdu}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
-
-## CPU Model.
-if [ -n "${cpumodel}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=servercpu" -d "ea=${cpumodel} ${cpucores} cores" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=servercpu" -d "ea=${cpumodel} ${cpucores} cores" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=servercpu" -d "ea=${cpumodel} ${cpucores} cores" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-
-fi
-
-## CPU Frequency.
-if [ -n "${cpufreqency}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=servercpufreq" -d "ea=${cpufreqency} x${cpucores}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=servercpufreq" -d "ea=${cpufreqency} x${cpucores}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=servercpufreq" -d "ea=${cpufreqency} x${cpucores}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
-
-## Server RAM.
-if [ -n "${physmemtotal}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=serverram" -d "ea=${physmemtotal}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=serverram" -d "ea=${physmemtotal}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=serverram" -d "ea=${physmemtotal}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
-
-## Server Disk.
-if [ -n "${totalspace}" ]; then
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=serverdisk" -d "ea=${totalspace}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=serverdisk" -d "ea=${totalspace}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=serverdisk" -d "ea=${totalspace}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-fi
+curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMWt4_vHi6ZpUw&measurement_id=G-0CR8V7EMT5" -H "Content-Type: application/json" -d "
+{
+	\"client_id\": \"${uuidinstance}\",
+	\"events\": [
+		{
+		\"name\": \"LinuxGSM\",
+		\"params\": {
+			\"cpuusedmhzroundup\": \"${cpuusedmhzroundup}MHz\",
+			\"memusedroundup\": \"${memusedroundup}MB\",
+			\"serverfilesdu\": \"${serverfilesdu}\",
+			\"uuidhardware\": \"${uuidhardware}\",
+			\"uuidinstall\": \"${uuidinstall}\",
+			\"uuidinstance\": \"${uuidinstance}\",
+			\"diskused\": \"${serverfilesdu}\",
+			\"distro\": \"${distroname}\",
+			\"game\": \"${gamename}\",
+			\"ramused\": \"${memusedroundup}MB\",
+			\"servercpu\": \"${cpumodel} ${cpucores} cores\",
+			\"servercpufreq\": \"${cpufreqency} x${cpucores}\",
+			\"serverdisk\": \"${totalspace}\",
+			\"serverram\": \"${physmemtotal}\",
+			\"version\": \"${version}\"
+			}
+		}
+	]
+}"
 
 ## Alert Stats.
 if [ "${discordalert}" == "on" ]; then
@@ -152,11 +117,6 @@ fi
 if [ "${telegramalert}" == "on" ]; then
 	curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=alert" -d "ea=Telegram" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 fi
-
-## Summary Stats
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-1" -d "aip=1" -d "cid=${uuidinstance}" -d "t=event" -d "ec=summary" -d "ea=GAME: ${gamename} | DISTRO: ${distroname} | CPU MODEL: ${cpumodel} ${cpucores} cores | RAM: ${physmemtotal} | DISK: ${totalspace}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-2" -d "aip=1" -d "cid=${uuidinstall}" -d "t=event" -d "ec=summary" -d "ea=GAME: ${gamename} | DISTRO: ${distroname} | CPU MODEL: ${cpumodel} ${cpucores} cores | RAM: ${physmemtotal} | DISK: ${totalspace}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
-curl https://www.google-analytics.com/collect -d "tid=UA-165287622-3" -d "aip=1" -d "cid=${uuidhardware}" -d "t=event" -d "ec=summary" -d "ea=GAME: ${gamename} | DISTRO: ${distroname} | CPU MODEL: ${cpumodel} ${cpucores} cores | RAM: ${physmemtotal} | DISK: ${totalspace}" -d "el=${gamename}" -d "v=1" > /dev/null 2>&1
 
 fn_script_log_info "Send LinuxGSM stats"
 fn_script_log_info "* uuid-${selfname}: ${uuidinstance}"

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -91,7 +91,7 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 curl -i -X POST https://stats.linuxgsm.com/api/event \
 	-H 'User-Agent: curl' \
 	-H 'Content-Type: application/json' \
-	--data "{\"name\":\"linuxgsm\",
+	--data "{\"name\":\"pageview\",
 				\"url\":\"https://stats.linuxgsm.com\",
 				\"domain\":\"stats.linuxgsm.com\",
 				\"cpuusedmhzroundup\": \"${cpuusedmhzroundup}MHz\",

--- a/lgsm/modules/info_stats.sh
+++ b/lgsm/modules/info_stats.sh
@@ -83,7 +83,7 @@ curl -X POST "https://www.google-analytics.com/mp/collect?api_secret=A-OzP02TSMW
 			\"uuidinstall\": \"${uuidinstall}\",
 			\"uuidinstance\": \"${uuidinstance}\",
 			\"version\": \"${version}\",
-			\"virtualenvironment\": \"${virtualenvironment}\"
+			\"virtualenvironment\": \"${virtualenvironment}\",
 			\"discordalert\": \"${discordalert}\",
 			\"emailalert\": \"${emailalert}\",
 			\"gotifyalert\": \"${gotifyalert}\",


### PR DESCRIPTION
# Description

LinuxGSM stats has been migrated to use Google GA-4 which replaces Google Universal Analytics (UA). This PR drastically streamlines and reduces the number of curl requests to analytics. The only missing functionality currently is country which is not yet available in the event-driven API (hopefully will be added later).

New stats added for virtual environment type which will help identify people useing the docker container, bare metal, or VM.


Fixes #[issue]

## Type of change

-   [ ] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [x] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [ ] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [ ] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
