### PR TITLE
fix: resolve edge case where RHEL servers might have dpkg installed

### DIFF
--- a/lgsm/modules/check_deps.sh
+++ b/lgsm/modules/check_deps.sh
@@ -93,16 +93,16 @@ fn_deps_email() {
 				array_deps_required+=(exim4)
 			elif [ -d /etc/sendmail ]; then
 				array_deps_required+=(sendmail)
-			elif [ "$(command -v dpkg-query 2> /dev/null)" ]; then
-				array_deps_required+=(mailutils postfix)
-			elif [ "$(command -v rpm 2> /dev/null)" ]; then
+			elif [ "$(command -v yum 2> /dev/null)" ] || [ "$(command -v dnf 2> /dev/null)" ]; then
 				array_deps_required+=(mailx postfix)
+			elif [ "$(command -v apt 2> /dev/null)" ]; then
+				array_deps_required+=(mailutils postfix)
 			fi
 		else
-			if [ "$(command -v dpkg-query 2> /dev/null)" ]; then
-				array_deps_required+=(mailutils postfix)
-			elif [ "$(command -v rpm 2> /dev/null)" ]; then
+			ielif [ "$(command -v yum 2> /dev/null)" ] || [ "$(command -v dnf 2> /dev/null)" ]; then
 				array_deps_required+=(mailx postfix)
+			elif [ "$(command -v apt 2> /dev/null)" ]; then
+				array_deps_required+=(mailutils postfix)
 			fi
 		fi
 	fi
@@ -144,7 +144,7 @@ fn_install_missing_deps() {
 		fi
 
 		# Add sudo dpkg --add-architecture i386 if using i386 packages.
-		if [ "$(command -v dpkg-query 2> /dev/null)" ]; then
+		if [ "$(command -v apt 2> /dev/null)" ]; then
 			if printf '%s\n' "${array_deps_required[@]}" | grep -q -P 'i386'; then
 				i386installcommand="sudo dpkg --add-architecture i386; "
 			fi
@@ -161,7 +161,7 @@ fn_install_missing_deps() {
 			echo -en "...\r"
 			sleep 1
 			echo -en "   \r"
-			if [ "$(command -v dpkg-query 2> /dev/null)" ]; then
+			if [ "$(command -v apt 2> /dev/null)" ]; then
 				cmd="echo steamcmd steam/question select \"I AGREE\" | sudo debconf-set-selections; echo steamcmd steam/license note '' | sudo debconf-set-selections; ${i386installcommand}sudo apt-get update; sudo apt-get -y install ${array_deps_missing[*]}"
 				eval "${cmd}"
 			elif [ "$(command -v dnf 2> /dev/null)" ]; then
@@ -181,7 +181,7 @@ fn_install_missing_deps() {
 
 		# If automatic dependency install is unavailable.
 		if [ "${autodepinstall}" != "0" ]; then
-			if [ "$(command -v dpkg-query 2> /dev/null)" ]; then
+			if [ "$(command -v apt 2> /dev/null)" ]; then
 				echo -e "${i386installcommand}sudo apt update; sudo apt install ${array_deps_missing[*]}"
 			elif [ "$(command -v dnf 2> /dev/null)" ]; then
 				echo -e "sudo dnf install ${array_deps_missing[*]}"
@@ -254,7 +254,7 @@ fn_deps_detector() {
 			depstatus=1
 			monostatus=1
 		fi
-	elif [ "$(command -v dpkg-query 2> /dev/null)" ]; then
+	elif [ "$(command -v apt 2> /dev/null)" ]; then
 		dpkg-query -W -f='${Status}' "${deptocheck}" 2> /dev/null | grep -q -P '^install ok installed'
 		depstatus=$?
 	elif [ "$(command -v dnf 2> /dev/null)" ]; then


### PR DESCRIPTION
# Description

For reasons unknown you can install dpkg in RHEL so instead this now looks for apt, yum or dnf

Fixes #4251 

## Type of change

-   [ ] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [x] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
