### PR TITLE
docs: replace gamedig repository links to the actual repository

### DIFF
--- a/lgsm/functions/query_gamedig.sh
+++ b/lgsm/functions/query_gamedig.sh
@@ -4,7 +4,7 @@
 # Contributors: http://linuxgsm.com/contrib
 # Website: https://linuxgsm.com
 # Description: Querys a gameserver using node-gamedig.
-# https://github.com/sonicsnes/node-gamedig
+# https://github.com/gamedig/node-gamedig
 
 functionselfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
 querystatus="2"

--- a/lgsm/modules/query_gamedig.sh
+++ b/lgsm/modules/query_gamedig.sh
@@ -4,7 +4,7 @@
 # Contributors: http://linuxgsm.com/contrib
 # Website: https://linuxgsm.com
 # Description: Querys a gameserver using node-gamedig.
-# https://github.com/sonicsnes/node-gamedig
+# https://github.com/gamedig/node-gamedig
 
 moduleselfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
 # Default query status to failure. Will be changed to 0 if query is successful.


### PR DESCRIPTION
# Description
Replaces the link references to the node-GameDig repository to the actual one.
Fixes #4337.

## Type of change

-   [ ] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [x] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

The [User docs](https://github.com/GameServerManagers/LinuxGSM-Docs) has a reference like the one that this PR replaces (will also make a PR there), the [Dev docs](https://github.com/GameServerManagers/LinuxGSM-Dev-Docs) does not, as the reference link is the correct one.

**Thank you for your Pull Request!**
