### PR TITLE
feat(vh): add an additional config string for valheim world modifiers

### DIFF
--- a/lgsm/config-default/config-lgsm/vhserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vhserver/_default.cfg
@@ -28,24 +28,27 @@ crossplay=""
 # INSTRUCTIONS FOR WORLD MODIFIERS (from Valheim Dedicated Server Manual.pdf located in serverfiles)
 # World modifiers can only be set in the start parameters and can be a combination of the following
 # PRESETS:
-# 	Setting a preset will overwrite any other previous modifiers.
-# 	Command line parameter: -preset
-# 	Valid values: normal, casual, easy, hard, hardcore, immersive, hammer.
+#   Setting a preset will overwrite any other previous modifiers.
+#   Command line parameter: -preset
+#   Valid values: normal, casual, easy, hard, hardcore, immersive, hammer.
 # MODIFIERS:
-# 	This is set as a combination of key and value, if combined with a preset should be set after.
-# 	Command line parameter: -modifier
-# 	Valid keys and possible values:
-# 	combat: veryeasy, easy, hard, veryhard
-# 	deathPenalty: casual, veryeasy, easy, hard, hardcore
-# 	resources: muchless, less, more, muchmore, most
-# 	raids: none, muchless, less, more, muchmore
-# 	portals: casual, hard, veryhard
+#   This is set as a combination of key and value, if combined with a preset should be set after.
+#   Command line parameter: -modifier
+#   Valid keys and possible values:
+#   combat: veryeasy, easy, hard, veryhard
+#   deathPenalty: casual, veryeasy, easy, hard, hardcore
+#   resources: muchless, less, more, muchmore, most
+#   raids: none, muchless, less, more, muchmore
+#   portals: casual, hard, veryhard
 # KEYS:
-# 	Sets a world modifier checkbox key.
-# 	Command line parameter: -setkey
-# 	Valid values: nobuildcost, playerevents, passivemobs, nomap
-# Example of a cobination of modifiers where we set no raids, very hard portals and no map run:
-# modifiers="-modifier raids none -modifier portals veryhard -setkey nomap"
+#   Sets a world modifier checkbox key.
+#   Command line parameter: -setkey
+#   Valid values: nobuildcost, playerevents, passivemobs, nomap
+# Example of a combination of modifiers where we set no raids, very hard portals and no map run:
+#   modifiers="-modifier raids none -modifier portals veryhard -setkey nomap"
+# NOTE: removing world modifiers will NOT reset them to default. the modifiers are stored in the world save file (.fwl)
+#   To go back to default you need to launch the server with the following parameter at least once:
+#.  modifiers="-preset normal"
 
 worldmodifiers=""
 

--- a/lgsm/config-default/config-lgsm/vhserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vhserver/_default.cfg
@@ -45,10 +45,10 @@ crossplay=""
 #   Command line parameter: -setkey
 #   Valid values: nobuildcost, playerevents, passivemobs, nomap
 # Example of a combination of modifiers where we set no raids, very hard portals and no map run:
-#   modifiers="-modifier raids none -modifier portals veryhard -setkey nomap"
+#   worldmodifiers="-modifier raids none -modifier portals veryhard -setkey nomap"
 # NOTE: removing world modifiers will NOT reset them to default. the modifiers are stored in the world save file (.fwl)
 #   To go back to default you need to launch the server with the following parameter at least once:
-#.  modifiers="-preset normal"
+#.  worldmodifiers="-preset normal"
 
 worldmodifiers=""
 

--- a/lgsm/config-default/config-lgsm/vhserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vhserver/_default.cfg
@@ -22,11 +22,35 @@ backups="4"
 backupshort="7200"
 backuplong="43200"
 # If crossplay is empty, it's off. Fill with any text to make true
-# Crossplay is currently not working on Linux dedicated servers, so for now the default is false (emtpy)
+# Crossplay is currently not working on Linux dedicated servers, so for now the default is false (empty)
 crossplay=""
 
+# INSTRUCTIONS FOR WORLD MODIFIERS (from Valheim Dedicated Server Manual.pdf located in serverfiles)
+# World modifiers can only be set in the start parameters and can be a combination of the following
+# PRESETS:
+# 	Setting a preset will overwrite any other previous modifiers.
+# 	Command line parameter: -preset
+# 	Valid values: normal, casual, easy, hard, hardcore, immersive, hammer.
+# MODIFIERS:
+# 	This is set as a combination of key and value, if combined with a preset should be set after.
+# 	Command line parameter: -modifier
+# 	Valid keys and possible values:
+# 	combat: veryeasy, easy, hard, veryhard
+# 	deathPenalty: casual, veryeasy, easy, hard, hardcore
+# 	resources: muchless, less, more, muchmore, most
+# 	raids: none, muchless, less, more, muchmore
+# 	portals: casual, hard, veryhard
+# KEYS:
+# 	Sets a world modifier checkbox key.
+# 	Command line parameter: -setkey
+# 	Valid values: nobuildcost, playerevents, passivemobs, nomap
+# Example of a cobination of modifiers where we set no raids, very hard portals and no map run:
+# modifiers="-modifier raids none -modifier portals veryhard -setkey nomap"
+
+worldmodifiers=""
+
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="-name '${servername}' -password ${serverpassword} -port ${port} -world ${worldname} -public ${public} -savedir '${savedir}' -logFile '${logFile}' -saveinterval ${saveinterval} -backups ${backups} -backupshort ${backupshort} -backuplong ${backuplong} ${crossplay:+-crossplay}"
+startparameters="-name '${servername}' -password ${serverpassword} -port ${port} -world ${worldname} -public ${public} -savedir '${savedir}' -saveinterval ${saveinterval} -backups ${backups} -backupshort ${backupshort} -backuplong ${backuplong}${logFile:+ -logFile '${logFile}'}${crossplay:+ -crossplay}${worldmodifiers:+ ${worldmodifiers}}"
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
# Description

Valheim world modifiers can be set in the executable start parameters as is documented in the manual pdf included in the server root directory.
Initially I wanted to create a separate config string for each modifier type but since they can be used multiple times (they can be mixed with each other) we would need complex logic to handle it that cannot fit in the cfg file.

for example: let's say I want to have a world with no raids, hard portals and easy no map, i would need to add these parameters:
`-modifier raids none -modifier portals veryhard -setkey nomap`
notice how `-modifier` is used twice and uses a combination of key and value, ideally we should have a `modifier` csv string with all the options that can be split into an array and then iterate on it to form the final string. But there is no room to fit all this logic so I came up with this fairly simple solution where a server admin can just put all the modifiers in one string and they will be added to start parameters (if set).
I have added in the cfg file also a commentary to explain how to set the parameters mirroring what's explained int the official documentation pdf.

Fixes #4328 

## Type of change

-   [ ] Bug fix (a change which fixes an issue).
-   [x] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
