### PR TITLE
refactor: remove ansi sequence from creeol when ansi=off

### DIFF
--- a/lgsm/modules/core_messages.sh
+++ b/lgsm/modules/core_messages.sh
@@ -10,6 +10,8 @@ moduleselfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
 # nl: new line: message is following by a new line.
 # eol: end of line: message is placed at the end of the current line.
 fn_ansi_loader() {
+	# carriage return.
+	creeol="\r"
 	if [ "${ansi}" != "off" ]; then
 		# echo colors
 		default="\e[0m"
@@ -29,9 +31,9 @@ fn_ansi_loader() {
 		darkgrey="\e[90m"
 		lightgrey="\e[37m"
 		white="\e[97m"
+  		# erase to end of line.
+		creeol+="\033[K"
 	fi
-	# carriage return & erase to end of line.
-	creeol="\r\033[K"
 }
 
 fn_sleep_time() {


### PR DESCRIPTION
# Description

When using "ansi"="off", the escape sequence \033[K is still present and tools that input from lgsm will get thoses bytes.
![image](https://github.com/GameServerManagers/LinuxGSM/assets/13225186/0001dc9c-4b68-4d57-a3a6-c50b666070e6)
This commit removes that.
![image](https://github.com/GameServerManagers/LinuxGSM/assets/13225186/faf673c0-8d05-4e2b-856f-9e614a3db8c4)

One side-effect if two prints are done without a line feed and the second is shorter than the first, then some unwanted character could remain.
```
echo -en "${creeol}foo/bar"
echo -en "${creeol}foo"
```
* before : prints "foo"
* after: prints "foo/bar"

## Type of change

-   [ ] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [x] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue. (The bug is in the PR)
-   [x] This pull request uses the `develop` branch as its base.
-   [ ] This pull request subject follows the Conventional Commits standard.
-   [ ] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [ ] I have checked if documentation needs updating.

## Documentation

Yea, the ANSI doc is lacklust and should at least explains a little bit this option for non tech user
https://docs.linuxgsm.com/features/ansi-colors

**Thank you for your Pull Request!**
