### PR TITLE
 fix(rust): add default-terminal setting for Oxide

### DIFF
--- a/lgsm/config-default/config-lgsm/rustserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rustserver/_default.cfg
@@ -28,7 +28,7 @@ saveinterval="300" # Auto-save in seconds.
 tickrate="30"      # default: 30, range: 15-100.
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="-batchmode +app.listenip ${ip} +app.port ${appport} +server.ip ${ip} +server.port ${port} +server.queryport ${queryport} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${selfname}\" +server.gamemode ${gamemode} +server.level \"${serverlevel}\" +server.seed ${seed} +server.salt ${salt} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile"
+startparameters="-batchmode +app.listenip ${ip} +app.port ${appport} +server.ip ${ip} +server.port ${port} +server.queryport ${queryport} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${selfname}\" +server.gamemode ${gamemode} +server.level \"${serverlevel}\" +server.seed ${seed} +server.salt ${salt} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile ${gamelog}"
 
 #### LinuxGSM Settings ####
 
@@ -184,6 +184,7 @@ backupdir="${lgsmdir}/backup"
 gamelogdir="${logdir}/server"
 lgsmlogdir="${logdir}/script"
 consolelogdir="${logdir}/console"
+gamelog="${gamelogdir}/${selfname}-game.log"
 lgsmlog="${lgsmlogdir}/${selfname}-script.log"
 consolelog="${consolelogdir}/${selfname}-console.log"
 alertlog="${lgsmlogdir}/${selfname}-alert.log"

--- a/lgsm/modules/fix_rust.sh
+++ b/lgsm/modules/fix_rust.sh
@@ -36,7 +36,6 @@ fi
 if [ -f "${serverfiles}/RustDedicated_Data/Managed/Oxide.Rust.dll" ]; then
 	# tmux version is 3.3 or higher
 	tmuxvdigit="$(tmux -V | sed "s/tmux //" | sed -n '1 p' | tr -cd '[:digit:]')"
-
 	if [ "${tmuxvdigit}" -ge "33" ]; then
 		if [ ! -f "${HOME}/.tmux.conf" ]; then
 			touch "${HOME}/.tmux.conf"
@@ -46,7 +45,6 @@ if [ -f "${serverfiles}/RustDedicated_Data/Managed/Oxide.Rust.dll" ]; then
 			fn_fix_msg_start
 			echo "set -g default-terminal \"screen-256color\"" >> "${HOME}/.tmux.conf"
 			fn_fix_msg_end
-
 		fi
 	fi
 fi

--- a/lgsm/modules/fix_rust.sh
+++ b/lgsm/modules/fix_rust.sh
@@ -30,3 +30,23 @@ if [ -f "${serverfiles}/carbon/tools/environment.sh" ]; then
 	# shellcheck source=/dev/null
 	source "${serverfiles}/carbon/tools/environment.sh"
 fi
+
+# fix for #4268
+# insert set -g default-terminal "screen-256color" into ~/.tmux.conf
+if [ -f "${serverfiles}/RustDedicated_Data/Managed/Oxide.Rust.dll" ]; then
+	# tmux version is 3.3 or higher
+	tmuxvdigit="$(tmux -V | sed "s/tmux //" | sed -n '1 p' | tr -cd '[:digit:]')"
+
+	if [ "${tmuxvdigit}" -ge "33" ]; then
+		if [ ! -f "${HOME}/.tmux.conf" ]; then
+			touch "${HOME}/.tmux.conf"
+		fi
+		if ! grep -q "set -g default-terminal \"screen-256color\"" "${HOME}/.tmux.conf"; then
+			fixname="tmux screen-256color"
+			fn_fix_msg_start
+			echo "set -g default-terminal \"screen-256color\"" >> "${HOME}/.tmux.conf"
+			fn_fix_msg_end
+
+		fi
+	fi
+fi


### PR DESCRIPTION
# Description

Forces `screen-256color` if using Oxide and tmux 3.3 and above.

Fixes #4267

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
