### PR TITLE
fix(install): non-free is now correctly detected

### DIFF
--- a/lgsm/modules/check_deps.sh
+++ b/lgsm/modules/check_deps.sh
@@ -252,7 +252,7 @@ fn_deps_detector() {
 	elif [ "${deptocheck}" == "steamcmd" ] && [ -z "${appid}" ]; then
 		array_deps_required=("${array_deps_required[@]/steamcmd/}")
 		steamcmdstatus=1
-	elif [ "${deptocheck}" == "steamcmd" ] && [ "${distroid}" == "debian" ] && ! grep -qE "^deb .*non-free" /etc/apt/sources.list; then
+	elif [ "${deptocheck}" == "steamcmd" ] && [ "${distroid}" == "debian" ] && ! grep -qE '[^deb]+non-free([^-]|$)' /etc/apt/sources.list; then
 		array_deps_required=("${array_deps_required[@]/steamcmd/}")
 		steamcmdstatus=1
 	# Java: Added for users using Oracle JRE to bypass check.


### PR DESCRIPTION
# Description

Debian has added non-free-firmware repo. This was being detected alongside non-free and causing issues with steamcmd installation. this fix ensures non-free is only detected.

Fixes #4374 

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
