### PR TITLE
fix(monitor): Quake2/Quake3 query fix for ./wfserver monitor (and other quake games)

### DIFF
--- a/lgsm/modules/query_gsquery.py
+++ b/lgsm/modules/query_gsquery.py
@@ -10,13 +10,13 @@ import argparse
 import socket
 import sys
 
-engine_types=('protocol-valve','protocol-quake3','protocol-quake3','protocol-gamespy1','protocol-unreal2','ut3','minecraft','minecraftbe','jc2mp','mumbleping','soldat','teeworlds')
+engine_types=('protocol-valve','protocol-quake2','protocol-quake3','protocol-gamespy1','protocol-unreal2','ut3','minecraft','minecraftbe','jc2mp','mumbleping','soldat','teeworlds')
 
 class gsquery:
     server_response_timeout = 2
     default_buffer_length = 1024
     sourcequery=('protocol-valve','avalanche3.0','barotrauma','madness','quakelive','realvirtuality','refractor','source','goldsrc','spark','starbound','unity3d','unreal4','wurm')
-    idtech2query=('protocol-quake3','idtech2','quake','iw2.0')
+    idtech2query=('protocol-quake2','idtech2','quake','iw2.0')
     idtech3query=('protocol-quake3','iw3.0','ioquake3','qfusion')
     minecraftquery=('minecraft','lwjgl2')
     minecraftbequery=('minecraftbe',)


### PR DESCRIPTION
# Description

Hi,

since a few months I have a problem that the first query for ./wfserver monitor works fine but subsequent are not. Therefore the server will be restarted every time one does run the monitor command.

It seems that the python gameserver query had a misspelling for the "protocol-quake3" which lead to false offline notifications for both quake2 and quake3 servers because quake2 wasn't found anymore and quake3 used the quake2 command to check for the server response.


Fixes #4409

## Type of change

-   [X] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [X] This pull request links to an issue.
-   [X] This pull request uses the `develop` branch as its base.
-   [X] This pull request subject follows the Conventional Commits standard.
-   [X] This code follows the style guidelines of this project.
-   [X] I have performed a self-review of my code.
-   [X] I have checked that this code is commented where required.
-   [X] I have provided a detailed enough description of this PR.
-   [X] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
