### PR TITLE
Add server browser tags to rustserver config

### DIFF
--- a/lgsm/config-default/config-lgsm/rustserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rustserver/_default.cfg
@@ -26,9 +26,10 @@ maxplayers="50"
 worldsize="3000"   # default: 3000, range: 1000-6000, map size in meters.
 saveinterval="300" # Auto-save in seconds.
 tickrate="30"      # default: 30, range: 15-100.
+tags=""            # values: monthly, biweekly, weekly, vanilla, hardcore, softcore, pve, roleplay, creative, minigame, training, battlefield, broyale, builds, NA, SA, EU, WA, EA, OC, AF ( Doc: https://wiki.facepunch.com/rust/server-browser-tags )
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
-startparameters="-batchmode +app.listenip ${ip} +app.port ${appport} +server.ip ${ip} +server.port ${port} +server.queryport ${queryport} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${selfname}\" +server.gamemode ${gamemode} +server.level \"${serverlevel}\" +server.seed ${seed} +server.salt ${salt} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" -logfile ${gamelog}"
+startparameters="-batchmode +app.listenip ${ip} +app.port ${appport} +server.ip ${ip} +server.port ${port} +server.queryport ${queryport} +server.tickrate ${tickrate} +server.hostname \"${servername}\" +server.identity \"${selfname}\" +server.gamemode ${gamemode} +server.level \"${serverlevel}\" +server.seed ${seed} +server.salt ${salt} +server.maxplayers ${maxplayers} +server.worldsize ${worldsize} +server.saveinterval ${saveinterval} +rcon.web ${rconweb} +rcon.ip ${ip} +rcon.port ${rconport} +rcon.password \"${rconpassword}\" +server.tags ${tags} -logfile ${gamelog}"
 
 #### LinuxGSM Settings ####
 


### PR DESCRIPTION
# Description

Adds a new parameter to the rustserver config, that allow specification of server browser tags. Those tags will be displayed on your server in the server browser.

Fixes #4417

## Type of change

-   [ ] Bug fix (a change which fixes an issue).
-   [x] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
