### PR TITLE
chore: only run GitHub actions when on main account

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   add-to-project:
+    if: github.repository_owner == 'GameServerManagers'
     runs-on: ubuntu-latest
     steps:
       - name: Add to Project

--- a/.github/workflows/details-check.yml
+++ b/.github/workflows/details-check.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   create-matrix:
+    if: github.repository_owner == 'GameServerManagers'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -28,6 +29,7 @@ jobs:
           echo -n "matrix=${shortnamearray}" >> $GITHUB_OUTPUT
 
   details-check:
+    if: github.repository_owner == 'GameServerManagers'
     needs: create-matrix
     continue-on-error: true
     runs-on: ubuntu-latest

--- a/.github/workflows/git-sync.yml
+++ b/.github/workflows/git-sync.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   gitHub-to-bitbucket:
+    if: github.repository_owner == 'GameServerManagers'
     runs-on: ubuntu-latest
     steps:
       - name: SSH Agent

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   issue-labeler:
+    if: github.repository_owner == 'GameServerManagers'
     runs-on: ubuntu-latest
     steps:
       - name: Issue Labeler
@@ -22,6 +23,7 @@ jobs:
           include-title: 1
 
   is-sponsor-label:
+    if: github.repository_owner == 'GameServerManagers'
     runs-on: ubuntu-latest
     steps:
       - name: Is Sponsor Label

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   lock:
+    if: github.repository_owner == 'GameServerManagers'
     runs-on: ubuntu-latest
     steps:
       - name: Lock Threads

--- a/.github/workflows/potential-duplicates.yml
+++ b/.github/workflows/potential-duplicates.yml
@@ -5,6 +5,7 @@ on:
       - opened
 jobs:
   potential-duplicates:
+    if: github.repository_owner == 'GameServerManagers'
     runs-on: ubuntu-latest
     steps:
       - name: Potential Duplicates

--- a/.github/workflows/serverlist-validate.yml
+++ b/.github/workflows/serverlist-validate.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   serverlist-validate:
+    if: github.repository_owner == 'GameServerManagers'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/trigger-docker-build.yml
+++ b/.github/workflows/trigger-docker-build.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   trigger_build_docker-linuxgsm:
+    if: github.repository_owner == 'GameServerManagers'
     name: Trigger Build Docker LinuxGSM
     runs-on: ubuntu-latest
     steps:
@@ -18,6 +19,7 @@ jobs:
           workflow_file_name: docker-publish.yml
 
   trigger_build_docker-gameserver:
+    if: github.repository_owner == 'GameServerManagers'
     name: Trigger Build Docker GameServer
     needs: trigger_build_docker-linuxgsm
     runs-on: ubuntu-latest

--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   update-check:
+    if: github.repository_owner == 'GameServerManagers'
     continue-on-error: true
     runs-on: ubuntu-latest
 

--- a/.github/workflows/update-copyright-years-in-license-file.yml
+++ b/.github/workflows/update-copyright-years-in-license-file.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   update-license-year:
+    if: github.repository_owner == 'GameServerManagers'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   version-Check:
+    if: github.repository_owner == 'GameServerManagers'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
[i opted to remove the PR template for this particular pull due to its non-user-facing nature, thanks!]

the most prominent case being update-copyright-years-in-license-file altering commit history in forks depending on configuration (sometimes these type of PRs just auto-merge on forks, creating a merge conflict when they sync their fork for preparing a PR) additionally, some actions require secrets so they would fail anyway