### PR TITLE
feat(pwserver): port & steamport setting for palworld

### DIFF
--- a/lgsm/config-default/config-lgsm/pwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pwserver/_default.cfg
@@ -11,12 +11,13 @@
 ## Predefined Parameters | https://docs.linuxgsm.com/configuration/start-parameters
 servername="LinuxGSM"
 
-# Use game server config file to edit, used for port check script (workaround)
+# For community servers (serverlist) you need to change these settings (publicip & publicport) in the gameserver config file aswell
 port="8211"
+steamport="27015"
 
 ## Server Parameters | https://docs.linuxgsm.com/configuration/start-parameters#additional-parameters
 ## Game Server Docs | https://tech.palworldgame.com/dedicated-server-guide#linux
-startparameters="EpicApp=PalServer -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS -servername='${servername}'"
+startparameters="EpicApp=PalServer -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS -servername='${servername}' -port='${port}' -queryport='${steamport}'"
 
 #### LinuxGSM Settings ####
 

--- a/lgsm/modules/info_game.sh
+++ b/lgsm/modules/info_game.sh
@@ -1978,7 +1978,7 @@ fn_info_game_sdtd() {
 # Config Type: Parameters (with an ini)
 fn_info_game_sf() {
 	# Parameters
-	servername="${selfname:-"NOT SET"}"
+	servername="${servername:-"NOT SET"}"
 	port="${port:-"0"}"
 	queryport="${queryport:-"0"}"
 	beaconport="${beaconport:-"0"}"
@@ -2131,7 +2131,7 @@ fn_info_game_tw() {
 
 # Config Type: Parameters
 fn_info_game_unt() {
-	servername="${selfname:-"NOT SET"}"
+	servername="${servername:-"NOT SET"}"
 	port="${port:-"0"}"
 	queryport="${port}"
 	steamport="$((port + 1))"

--- a/lgsm/modules/info_game.sh
+++ b/lgsm/modules/info_game.sh
@@ -621,7 +621,7 @@ fn_info_game_pvr() {
 fn_info_game_pw() {
 	servername="${servername:-"NOT SET"}"
 	port="${port:-"0"}"
-	steamport="27015"
+	steamport="${steamport:-"0"}"
 	unknownport="1985"
 }
 


### PR DESCRIPTION
# Description

Allows the user to set steamqueryport & gameserver port in the start parameters

Fixes
https://github.com/GameServerManagers/LinuxGSM/issues/4454

## Type of change

-   [ ] Bug fix (a change which fixes an issue).
-   [X] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [X] This pull request links to an issue.
-   [X] This pull request uses the `develop` branch as its base.
-   [ ] This pull request subject follows the Conventional Commits standard.
-   [X] This code follows the style guidelines of this project.
-   [X] I have performed a self-review of my code.
-   [X] I have checked that this code is commented where required.
-   [X] I have provided a detailed enough description of this PR.
-   [ ] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
