### PR TITLE
fix(mods): metamod gamemode fix

### DIFF
--- a/lgsm/modules/core_modules.sh
+++ b/lgsm/modules/core_modules.sh
@@ -371,6 +371,11 @@ fix_csgo.sh() {
 	fn_fetch_module
 }
 
+fix_cs2.sh() {
+	modulefile="${FUNCNAME[0]}"
+	fn_fetch_module
+}
+
 fix_dst.sh() {
 	modulefile="${FUNCNAME[0]}"
 	fn_fetch_module

--- a/lgsm/modules/fix.sh
+++ b/lgsm/modules/fix.sh
@@ -52,7 +52,7 @@ fn_apply_fix() {
 	fi
 }
 
-apply_pre_start_fix=(arma3 armar ark av bt bo csgo cmw dst hw ins kf nmrih onset pvr rust rw samp sdtd sfc sof2 squad st tf2 terraria ts3 mcb mta unt vh wurm zmr)
+apply_pre_start_fix=(arma3 armar ark av bt bo csgo cs2 cmw dst hw ins kf nmrih onset pvr rust rw samp sdtd sfc sof2 squad st tf2 terraria ts3 mcb mta unt vh wurm zmr)
 apply_post_install_fix=(av kf kf2 ro ut2k4 ut ut3)
 
 # validate registered fixes for safe development

--- a/lgsm/modules/fix_cs2.sh
+++ b/lgsm/modules/fix_cs2.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# LinuxGSM fix_csgo.sh module
+# Author: https://github.com/pcace
+# Contributors: http://linuxgsm.com/contrib
+# Website: https://linuxgsm.com
+# Description: Resolves issues with Counter-Strike: Global Offensive.
+
+moduleselfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+# Fixes: metamod installation (if installed) on cs2 updates
+GAMEINFO="${serverfiles}/game/csgo/gameinfo.gi"
+METAMOD_DIR="${serverfiles}/game/csgo/addons/metamod"
+
+if [ -d "$METAMOD_DIR" ]; then
+
+    # Remove Windows line endings (\r) from gameinfo.gi
+    sed -i 's/\r$//' "$GAMEINFO"
+
+    # Check if the line "Game    csgo/addons/metamod" exists in the file
+    if ! grep -q "Game    csgo/addons/metamod" "$GAMEINFO"; then
+
+        # Open gameinfo.gi in the game/csgo directory
+        sed -i 's/#.*\n//g' "$GAMEINFO"
+
+        # Add Game csgo/addons/metamod to the SearchPaths section
+        sed -i '/Game_LowViolence/{
+            a             Game    csgo/addons/metamod
+        }' "$GAMEINFO"
+
+    fi
+fi


### PR DESCRIPTION
# Description

Only applies if metamod addon is installed on a cs2 server:
currently the gamemode.gi gets overwritten when updating the cs2 installation, but metamod needs to be referenced in the gamemod.gi by:
```Game    csgo/addons/metamod```

this fix adds the needed integration of metamod to the gamemod.gi file if it is not there and if metamod is installed.

Fixes #4492

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [X] This pull request links to an issue.
-   [X] This pull request uses the `develop` branch as its base.
-   [X] This pull request subject follows the Conventional Commits standard.
-   [X] This code follows the style guidelines of this project.
-   [X] I have performed a self-review of my code.
-   [X] I have checked that this code is commented where required.
-   [X] I have provided a detailed enough description of this PR.
-   [X] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
