### PR TITLE
fix(mcserver): change required jdk to 21

### DIFF
--- a/lgsm/data/almalinux-8.csv
+++ b/lgsm/data/almalinux-8.csv
@@ -64,7 +64,7 @@ kf
 kf2
 l4d
 l4d2
-mc,java-17-openjdk
+mc,java-21-openjdk
 mcb,libnsl
 mh
 mohaa,compat-libstdc++-33.i686
@@ -81,7 +81,7 @@ onset,mariadb-connector-c
 opfor
 pc
 pc2
-pmc,java-17-openjdk
+pmc,java-21-openjdk
 ps,GConf2
 pvkii
 pvr,libcxx
@@ -127,11 +127,11 @@ ut3
 ut99
 vh,glibc-devel
 vints,aspnetcore-runtime-7.0
-vpmc,java-17-openjdk
+vpmc,java-21-openjdk
 vs
 wet
 wf
-wmc,java-17-openjdk
+wmc,java-21-openjdk
 wurm,xorg-x11-server-Xvfb
 zmr,ncurses-libs.i686
 zps,ncurses-libs.i686

--- a/lgsm/data/almalinux-9.csv
+++ b/lgsm/data/almalinux-9.csv
@@ -64,7 +64,7 @@ kf
 kf2
 l4d
 l4d2
-mc,java-17-openjdk
+mc,java-21-openjdk
 mcb,libnsl
 mh
 mohaa,compat-libstdc++-33.i686
@@ -81,12 +81,12 @@ onset,mariadb-connector-c
 opfor
 pc
 pc2
-pmc,java-17-openjdk
+pmc,java-21-openjdk
 ps,GConf2
 pvkii
 pvr,libcxx
 pw
-pz,java-11-openjdk rng-tools
+pz,java-21-openjdk rng-tools
 q2
 q3
 q4
@@ -96,7 +96,7 @@ ricochet
 ro
 rtcw
 rust,zlib-devel
-rw,java-11-openjdk
+rw,java-21-openjdk
 samp
 sb
 sbots
@@ -127,11 +127,11 @@ ut3
 ut99
 vh,glibc-devel
 vints,aspnetcore-runtime-7.0
-vpmc,java-17-openjdk
+vpmc,java-21-openjdk
 vs
 wet
 wf
-wmc,java-17-openjdk
+wmc,java-21-openjdk
 wurm,xorg-x11-server-Xvfb
 zmr,ncurses-libs.i686
 zps,ncurses-libs.i686

--- a/lgsm/data/centos-7.csv
+++ b/lgsm/data/centos-7.csv
@@ -64,7 +64,7 @@ kf
 kf2
 l4d
 l4d2
-mc,java-11-openjdk
+mc,java-21-openjdk
 mcb,libnsl
 mh
 mohaa,compat-libstdc++-33.i686

--- a/lgsm/data/centos-8.csv
+++ b/lgsm/data/centos-8.csv
@@ -64,7 +64,7 @@ kf
 kf2
 l4d
 l4d2
-mc,java-17-openjdk
+mc,java-21-openjdk
 mcb,libnsl
 mh
 mohaa,compat-libstdc++-33.i686

--- a/lgsm/data/centos-9.csv
+++ b/lgsm/data/centos-9.csv
@@ -86,7 +86,7 @@ ps,GConf2
 pvkii
 pvr,libcxx
 pw
-pz,java-11-openjdk rng-tools
+pz,java-21-openjdk rng-tools
 q2
 q3
 q4
@@ -96,7 +96,7 @@ ricochet
 ro
 rtcw
 rust,zlib-devel
-rw,java-11-openjdk
+rw,java-21-openjdk
 samp
 sb
 sbots

--- a/lgsm/data/rhel-8.csv
+++ b/lgsm/data/rhel-8.csv
@@ -64,7 +64,7 @@ kf
 kf2
 l4d
 l4d2
-mc,java-17-openjdk
+mc,java-21-openjdk
 mcb,libnsl
 mh
 mohaa,compat-libstdc++-33.i686
@@ -81,12 +81,12 @@ onset,mariadb-connector-c
 opfor
 pc
 pc2
-pmc,java-17-openjdk
+pmc,java-21-openjdk
 ps,GConf2
 pvkii
 pvr,libcxx
 pw
-pz,java-11-openjdk rng-tools
+pz,java-21-openjdk rng-tools
 q2
 q3
 q4
@@ -96,7 +96,7 @@ ricochet
 ro
 rtcw
 rust,zlib-devel
-rw,java-11-openjdk
+rw,java-21-openjdk
 samp
 sb
 sbots
@@ -127,11 +127,11 @@ ut3
 ut99
 vh,glibc-devel
 vints,aspnetcore-runtime-7.0
-vpmc,java-17-openjdk
+vpmc,java-21-openjdk
 vs
 wet
 wf
-wmc,java-17-openjdk
+wmc,java-21-openjdk
 wurm,xorg-x11-server-Xvfb
 zmr,ncurses-libs.i686
 zps,ncurses-libs.i686

--- a/lgsm/data/rhel-9.csv
+++ b/lgsm/data/rhel-9.csv
@@ -64,7 +64,7 @@ kf
 kf2
 l4d
 l4d2
-mc,java-17-openjdk
+mc,java-21-openjdk
 mcb,libnsl
 mh
 mohaa,compat-libstdc++-33.i686
@@ -81,12 +81,12 @@ onset,mariadb-connector-c
 opfor
 pc
 pc2
-pmc,java-17-openjdk
+pmc,java-21-openjdk
 ps,GConf2
 pvkii
 pvr,libcxx
 pw
-pz,java-11-openjdk rng-tools
+pz,java-21-openjdk rng-tools
 q2
 q3
 q4
@@ -96,7 +96,7 @@ ricochet
 ro
 rtcw
 rust,zlib-devel
-rw,java-11-openjdk
+rw,java-21-openjdk
 samp
 sb
 sbots
@@ -127,11 +127,11 @@ ut3
 ut99
 vh,glibc-devel
 vints,aspnetcore-runtime-7.0
-vpmc,java-17-openjdk
+vpmc,java-21-openjdk
 vs
 wet
 wf
-wmc,java-17-openjdk
+wmc,java-21-openjdk
 wurm,xorg-x11-server-Xvfb
 zmr,ncurses-libs.i686
 zps,ncurses-libs.i686

--- a/lgsm/data/rocky-8.csv
+++ b/lgsm/data/rocky-8.csv
@@ -64,7 +64,7 @@ kf
 kf2
 l4d
 l4d2
-mc,java-17-openjdk
+mc,java-21-openjdk
 mcb,libnsl
 mh
 mohaa,compat-libstdc++-33.i686
@@ -81,12 +81,12 @@ onset,mariadb-connector-c
 opfor
 pc
 pc2
-pmc,java-17-openjdk
+pmc,java-21-openjdk
 ps,GConf2
 pvkii
 pvr,libcxx
 pw
-pz,java-11-openjdk rng-tools
+pz,java-21-openjdk rng-tools
 q2
 q3
 q4
@@ -96,7 +96,7 @@ ricochet
 ro
 rtcw
 rust,zlib-devel
-rw,java-11-openjdk
+rw,java-21-openjdk
 samp
 sb
 sbots
@@ -127,11 +127,11 @@ ut3
 ut99
 vh,glibc-devel
 vints,aspnetcore-runtime-7.0
-vpmc,java-17-openjdk
+vpmc,java-21-openjdk
 vs
 wet
 wf
-wmc,java-17-openjdk
+wmc,java-21-openjdk
 wurm,xorg-x11-server-Xvfb
 zmr,ncurses-libs.i686
 zps,ncurses-libs.i686

--- a/lgsm/data/rocky-9.csv
+++ b/lgsm/data/rocky-9.csv
@@ -64,7 +64,7 @@ kf
 kf2
 l4d
 l4d2
-mc,java-17-openjdk
+mc,java-21-openjdk
 mcb,libnsl
 mh
 mohaa,compat-libstdc++-33.i686
@@ -81,12 +81,12 @@ onset,mariadb-connector-c
 opfor
 pc
 pc2
-pmc,java-17-openjdk
+pmc,java-21-openjdk
 ps,GConf2
 pvkii
 pvr,libcxx
 pw
-pz,java-11-openjdk rng-tools
+pz,java-21-openjdk rng-tools
 q2
 q3
 q4
@@ -96,7 +96,7 @@ ricochet
 ro
 rtcw
 rust,zlib-devel
-rw,java-11-openjdk
+rw,java-21-openjdk
 samp
 sb
 sbots
@@ -127,11 +127,11 @@ ut3
 ut99
 vh,glibc-devel
 vints,aspnetcore-runtime-7.0
-vpmc,java-17-openjdk
+vpmc,java-21-openjdk
 vs
 wet
 wf
-wmc,java-17-openjdk
+wmc,java-21-openjdk
 wurm,xorg-x11-server-Xvfb
 zmr,ncurses-libs.i686
 zps,ncurses-libs.i686

--- a/lgsm/data/ubuntu-20.04.csv
+++ b/lgsm/data/ubuntu-20.04.csv
@@ -64,7 +64,7 @@ kf
 kf2
 l4d
 l4d2
-mc,openjdk-17-jre
+mc,openjdk-21-jre
 mcb
 mh
 mohaa,libstdc++5:i386
@@ -81,12 +81,12 @@ onset,libmariadb-dev
 opfor
 pc
 pc2
-pmc,openjdk-17-jre
+pmc,openjdk-21-jre
 ps,libgconf-2-4
 pvkii
 pvr,libc++1
 pw
-pz,openjdk-17-jre,rng-tools
+pz,openjdk-21-jre,rng-tools
 q2
 q3
 q4
@@ -96,7 +96,7 @@ ricochet
 ro
 rtcw
 rust,lib32z1
-rw,openjdk-17-jre
+rw,openjdk-21-jre
 samp
 sb
 sbots
@@ -131,7 +131,7 @@ vpmc,openjdk-11-jre
 vs
 wet
 wf
-wmc,openjdk-17-jre
+wmc,openjdk-21-jre
 wurm,xvfb
 zmr,libtinfo5:i386
 zps,libtinfo5:i386

--- a/lgsm/data/ubuntu-22.04.csv
+++ b/lgsm/data/ubuntu-22.04.csv
@@ -64,7 +64,7 @@ kf
 kf2
 l4d
 l4d2
-mc,openjdk-17-jre
+mc,openjdk-21-jre
 mcb
 mh
 mohaa,libstdc++5:i386
@@ -81,12 +81,12 @@ onset,libmariadb-dev
 opfor
 pc
 pc2
-pmc,openjdk-17-jre
+pmc,openjdk-21-jre
 ps,libgconf-2-4
 pvkii
 pvr,libc++1
 pw
-pz,openjdk-17-jre,rng-tools5
+pz,openjdk-21-jre,rng-tools5
 q2
 q3
 q4
@@ -96,7 +96,7 @@ ricochet
 ro
 rtcw
 rust,lib32z1
-rw,openjdk-17-jre
+rw,openjdk-21-jre
 samp
 sb
 sbots
@@ -127,11 +127,11 @@ ut3
 ut99
 vh,libc6-dev
 vints,aspnetcore-runtime-7.0
-vpmc,openjdk-17-jre
+vpmc,openjdk-21-jre
 vs
 wet
 wf
-wmc,openjdk-17-jre
+wmc,openjdk-21-jre
 wurm,xvfb
 zmr,libtinfo5:i386
 zps,libtinfo5:i386

--- a/lgsm/data/ubuntu-23.04.csv
+++ b/lgsm/data/ubuntu-23.04.csv
@@ -64,7 +64,7 @@ kf
 kf2
 l4d
 l4d2
-mc,openjdk-17-jre
+mc,openjdk-21-jre
 mcb
 mh
 mohaa,libstdc++5:i386

--- a/lgsm/data/ubuntu-23.10.csv
+++ b/lgsm/data/ubuntu-23.10.csv
@@ -64,7 +64,7 @@ kf
 kf2
 l4d
 l4d2
-mc,openjdk-17-jre
+mc,openjdk-21-jre
 mcb
 mh
 mohaa,libstdc++5:i386


### PR DESCRIPTION
# Description

As of the [latest patch](https://feedback.minecraft.net/hc/en-us/articles/26136167989005-Minecraft-Java-Edition-1-20-5-Armored-Paws), minecraft now requires Java 21 to run:
> The game now requires Java 21

Other distro's csv files also have to be updated.

Fixes #4564 

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
