### PR TITLE
Update _default.cfg

### DIFF
--- a/lgsm/config-default/config-lgsm/atsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/atsserver/_default.cfg
@@ -152,7 +152,7 @@ glibc="2.15"
 ## Game Server Directories
 systemdir="${serverfiles}"
 executabledir="${systemdir}/bin/linux_x64"
-executable="./amtrucks_server"
+executable="./server_launch.sh"
 servercfgdir="${HOME}/.local/share/American Truck Simulator"
 servercfg="server_config.sii"
 servercfgdefault="server_config.sii"


### PR DESCRIPTION
ATS needs to be launched via the server_launch.sh file and not amtrucks_server then it works, has been tested by me! Also, people need to realize they need to export_server_packages for ATS by starting their ATS game first and loading their game save then use WinSCP to find their .local directory as some server hosters may have this directory hidden(or at least my linux server had the .local directory hidden), anyway this should fix the current problem of the game server not starting, the rest is in the post stated hereto fix the game server from missing things: https://github.com/GameServerManagers/LinuxGSM/issues/4580

# Description

Please include a summary of the change and which issues are fixed.

Fixes #[issue]

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [ ] This pull request uses the `develop` branch as its base.
-   [ ] This pull request subject follows the Conventional Commits standard.
-   [ ] This code follows the style guidelines of this project.
-   [ ] I have performed a self-review of my code.
-   [ ] I have checked that this code is commented where required.
-   [ ] I have provided a detailed enough description of this PR.
-   [ ] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
