### PR TITLE
This commit regressed #3764. Enabling monitor on 7 Days to Die continually restarts the server

### DIFF
--- a/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
@@ -136,7 +136,7 @@ stopmode="8"
 # 3: gamedig
 # 4: gsquery
 # 5: tcp
-querymode="2"
+querymode="5"
 querytype="protocol-valve"
 
 ## Console type


### PR DESCRIPTION
# Description

https://github.com/GameServerManagers/LinuxGSM/pull/4510/files#r1673145468

- monitor query fail and therefore server restart loop

Fixes #4615, #3764 

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
