### PR TITLE
fix(fctrserver): parse updated version string correctly

### DIFF
--- a/lgsm/modules/info_game.sh
+++ b/lgsm/modules/info_game.sh
@@ -1310,7 +1310,7 @@ fn_info_game_fctr() {
 	# get server version if installed.
 	local factoriobin="${executabledir}${executable:1}"
 	if [ -f "${factoriobin}" ]; then
-		serverversion="$(${factoriobin} --version | grep "Version:" | awk '{print $2}')"
+		serverversion="$(${factoriobin} --version | grep -m 1 "Version:" | awk '{print $2}')"
 	fi
 }
 

--- a/lgsm/modules/update_fctr.sh
+++ b/lgsm/modules/update_fctr.sh
@@ -20,7 +20,7 @@ fn_update_localbuild() {
 	# Uses executable to get local build.
 	if [ -d "${executabledir}" ]; then
 		cd "${executabledir}" || exit
-		localbuild=$(${executable} --version | grep "Version:" | awk '{print $2}')
+		localbuild=$(${executable} --version | grep -m 1 "Version:" | awk '{print $2}')
 	fi
 	if [ -z "${localbuild}" ]; then
 		fn_print_error "Checking local build: ${remotelocation}: missing local build info"


### PR DESCRIPTION
# Description

Changes the command used to extract the server version to only take the first match so that it ignores the architecture string.

Fixes #4687 

## Type of change

-   [x] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
