### PR TITLE
docs(tf2/hl2dm): Add note about unrestricted_maxplayers param for TF2/HL2DM maxplayers

### DIFF
--- a/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
@@ -9,6 +9,8 @@
 #### Game Server Settings ####
 
 ## Predefined Parameters | https://docs.linuxgsm.com/configuration/start-parameters
+# Note that for HL2DM, maxplayers > 33 must be specified like so:
+# maxplayers="101 -unrestricted_maxplayers"
 ip="0.0.0.0"
 port="27015"
 clientport="27005"

--- a/lgsm/config-default/config-lgsm/tf2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tf2server/_default.cfg
@@ -9,6 +9,8 @@
 #### Game Server Settings ####
 
 ## Predefined Parameters | https://docs.linuxgsm.com/configuration/start-parameters
+# Note that for TF2, maxplayers > 33 must be specified like so:
+# maxplayers="101 -unrestricted_maxplayers"
 ip="0.0.0.0"
 port="27015"
 clientport="27005"


### PR DESCRIPTION
# Description

TF2 and HL2DM added support for >33 maxplayers, but this is locked behind an additional flag on startparameters `-unrestricted_maxplayers`. This adds a note to _default.cfg about this quirk.

## Type of change

-   [ ] Bug fix (a change which fixes an issue).
-   [ ] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [x] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [ ] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [ ] This code follows the style guidelines of this project.
-   [ ] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [ ] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
