### PR TITLE
feat(vints): add ability to select Vintage Story versions

### DIFF
--- a/lgsm/config-default/config-lgsm/vintsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vintsserver/_default.cfg
@@ -12,7 +12,7 @@
 startparameters="--dataPath ${servercfgdir}"
 
 ## Release Settings | https://docs.linuxgsm.com/game-servers/vintagestory#release-settings
-# Branch (stable|unstable)
+# Branch (stable|unstable|<version>)
 branch="stable"
 
 #### LinuxGSM Settings ####

--- a/lgsm/modules/update_vints.sh
+++ b/lgsm/modules/update_vints.sh
@@ -39,8 +39,10 @@ fn_update_remotebuild() {
 	remotebuildresponse=$(curl -s "${apiurl}")
 	if [ "${branch}" == "stable" ]; then
 		remotebuildversion=$(echo "${remotebuildresponse}" | jq -r '[ to_entries[] ] | .[].key' | grep -Ev "\-rc|\-pre" | sort -r -V | head -1)
-	else
+	elif [ "${branch}" == "unstable" ]; then
 		remotebuildversion=$(echo "${remotebuildresponse}" | jq -r '[ to_entries[] ] | .[].key' | grep -E "\-rc|\-pre" | sort -r -V | head -1)
+	else
+		remotebuildversion="${branch}"
 	fi
 	remotebuildfilename=$(echo "${remotebuildresponse}" | jq --arg remotebuildversion "${remotebuildversion}" -r '.[$remotebuildversion].linuxserver.filename')
 	remotebuildurl=$(echo "${remotebuildresponse}" | jq --arg remotebuildversion "${remotebuildversion}" -r '.[$remotebuildversion].linuxserver.urls.cdn')


### PR DESCRIPTION
# Description

Vintage story previously only allowed selecting between stable and unstable versions. This change allows entering a specific version of the game.

Fixes #4814

## Type of change

-   [ ] Bug fix (a change which fixes an issue).
-   [x] New feature (a change which adds functionality).
-   [ ] New Server (new server added).
-   [ ] Refactor (restructures existing code).
-   [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

-   [x] This pull request links to an issue.
-   [x] This pull request uses the `develop` branch as its base.
-   [x] This pull request subject follows the Conventional Commits standard.
-   [x] This code follows the style guidelines of this project.
-   [x] I have performed a self-review of my code.
-   [x] I have checked that this code is commented where required.
-   [x] I have provided a detailed enough description of this PR.
-   [x] I have checked if documentation needs updating.

## Documentation

If documentation does need updating either update it by creating a PR (preferred) or request a documentation update.

-   User docs: https://github.com/GameServerManagers/LinuxGSM-Docs
-   Dev docs: https://github.com/GameServerManagers/LinuxGSM-Dev-Docs

**Thank you for your Pull Request!**
