### PR TITLE
feat(alerts): add Flowtriq alert module for DDoS correlation

### DIFF
--- a/lgsm/config-default/config-lgsm/acserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/acserver/_default.cfg
@@ -64,6 +64,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ahl2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ahl2server/_default.cfg
@@ -72,6 +72,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ahlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ahlserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/arkserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arkserver/_default.cfg
@@ -69,6 +69,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/arma3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/arma3server/_default.cfg
@@ -83,6 +83,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/armarserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/armarserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/atsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/atsserver/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/avserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/avserver/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/bb2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bb2server/_default.cfg
@@ -73,6 +73,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/bbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bbserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/bdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bdserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/bf1942server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bf1942server/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/bfvserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bfvserver/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/bmdmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bmdmserver/_default.cfg
@@ -73,6 +73,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/boserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/boserver/_default.cfg
@@ -65,6 +65,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/bsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/bsserver/_default.cfg
@@ -77,6 +77,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/btlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/btlserver/_default.cfg
@@ -65,6 +65,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/btserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/btserver/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ccserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ccserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ckserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ckserver/_default.cfg
@@ -64,6 +64,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/cmwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cmwserver/_default.cfg
@@ -66,6 +66,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/cod2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cod2server/_default.cfg
@@ -66,6 +66,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/cod4server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cod4server/_default.cfg
@@ -66,6 +66,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/codserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/codserver/_default.cfg
@@ -66,6 +66,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/coduoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/coduoserver/_default.cfg
@@ -66,6 +66,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/codwawserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/codwawserver/_default.cfg
@@ -66,6 +66,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/colserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/colserver/_default.cfg
@@ -61,6 +61,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/cs2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cs2server/_default.cfg
@@ -72,6 +72,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/csczserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csczserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csgoserver/_default.cfg
@@ -104,6 +104,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/csserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/csserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/cssserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/cssserver/_default.cfg
@@ -73,6 +73,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ctserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ctserver/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/dabserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dabserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/dayzserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dayzserver/_default.cfg
@@ -83,6 +83,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/dmcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dmcserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/dodrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dodrserver/_default.cfg
@@ -66,6 +66,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/dodserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dodserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/dodsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dodsserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/doiserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/doiserver/_default.cfg
@@ -69,6 +69,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/dstserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dstserver/_default.cfg
@@ -70,6 +70,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/dysserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/dysserver/_default.cfg
@@ -73,6 +73,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ecoserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ecoserver/_default.cfg
@@ -63,6 +63,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/emserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/emserver/_default.cfg
@@ -73,6 +73,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/etlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/etlserver/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ets2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ets2server/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/fctrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/fctrserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/fofserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/fofserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/gmodserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/gmodserver/_default.cfg
@@ -78,6 +78,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/hcuserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hcuserver/_default.cfg
@@ -75,6 +75,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hl2dmserver/_default.cfg
@@ -70,6 +70,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/hldmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hldmserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/hldmsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hldmsserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/hwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hwserver/_default.cfg
@@ -78,6 +78,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/hzserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/hzserver/_default.cfg
@@ -65,6 +65,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/insserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/insserver/_default.cfg
@@ -74,6 +74,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/inssserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/inssserver/_default.cfg
@@ -77,6 +77,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/iosserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/iosserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/jc2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jc2server/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/jc3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jc3server/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/jk2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jk2server/_default.cfg
@@ -69,6 +69,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/kf2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/kf2server/_default.cfg
@@ -66,6 +66,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/kfserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/kfserver/_default.cfg
@@ -72,6 +72,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/l4d2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/l4d2server/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/l4dserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/l4dserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/mcbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mcbserver/_default.cfg
@@ -63,6 +63,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/mcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mcserver/_default.cfg
@@ -69,6 +69,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/mhserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mhserver/_default.cfg
@@ -69,6 +69,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/mohaaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mohaaserver/_default.cfg
@@ -65,6 +65,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/momserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/momserver/_default.cfg
@@ -66,6 +66,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/mtaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/mtaserver/_default.cfg
@@ -63,6 +63,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ndserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ndserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/necserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/necserver/_default.cfg
@@ -63,6 +63,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/nmrihserver/_default.cfg
@@ -73,6 +73,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ns2cserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ns2cserver/_default.cfg
@@ -75,6 +75,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ns2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ns2server/_default.cfg
@@ -76,6 +76,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/nsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/nsserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ohdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ohdserver/_default.cfg
@@ -70,6 +70,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/onsetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/onsetserver/_default.cfg
@@ -61,6 +61,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/opforserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/opforserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/pc2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pc2server/_default.cfg
@@ -64,6 +64,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/pcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pcserver/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/pmcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pmcserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/pvkiiserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pvkiiserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/pvrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pvrserver/_default.cfg
@@ -69,6 +69,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/pwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pwserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/pzserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/pzserver/_default.cfg
@@ -64,6 +64,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/q2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/q2server/_default.cfg
@@ -65,6 +65,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/q3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/q3server/_default.cfg
@@ -65,6 +65,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/q4server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/q4server/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/qlserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qlserver/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/qwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/qwserver/_default.cfg
@@ -64,6 +64,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ricochetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ricochetserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/roserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/roserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/rtcwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rtcwserver/_default.cfg
@@ -65,6 +65,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/rustserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rustserver/_default.cfg
@@ -80,6 +80,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/rwserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/rwserver/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/sampserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sampserver/_default.cfg
@@ -64,6 +64,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/sbotsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sbotsserver/_default.cfg
@@ -66,6 +66,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/sbserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sbserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/scpslserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/scpslserver/_default.cfg
@@ -65,6 +65,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/scpslsmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/scpslsmserver/_default.cfg
@@ -65,6 +65,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sdtdserver/_default.cfg
@@ -63,6 +63,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/sfcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sfcserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/sfserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sfserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/smserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/smserver/_default.cfg
@@ -71,6 +71,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/sof2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/sof2server/_default.cfg
@@ -65,6 +65,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/solserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/solserver/_default.cfg
@@ -64,6 +64,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/squad44server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/squad44server/_default.cfg
@@ -65,6 +65,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/squadserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/squadserver/_default.cfg
@@ -65,6 +65,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/stnserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/stnserver/_default.cfg
@@ -64,6 +64,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/stserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/stserver/_default.cfg
@@ -64,6 +64,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/svenserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/svenserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/terrariaserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/terrariaserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/tf2cserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tf2cserver/_default.cfg
@@ -75,6 +75,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/tf2server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tf2server/_default.cfg
@@ -75,6 +75,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/tfcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tfcserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/tfserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tfserver/_default.cfg
@@ -84,6 +84,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/tiserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tiserver/_default.cfg
@@ -66,6 +66,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ts3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ts3server/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/tsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tsserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/tuserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/tuserver/_default.cfg
@@ -70,6 +70,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/twserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/twserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/untserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/untserver/_default.cfg
@@ -74,6 +74,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ut2k4server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut2k4server/_default.cfg
@@ -64,6 +64,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ut3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut3server/_default.cfg
@@ -80,6 +80,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/ut99server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/ut99server/_default.cfg
@@ -64,6 +64,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/utserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/utserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/vhserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vhserver/_default.cfg
@@ -101,6 +101,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/vintsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vintsserver/_default.cfg
@@ -64,6 +64,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/vpmcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vpmcserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/vsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/vsserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/wetserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wetserver/_default.cfg
@@ -60,6 +60,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/wfserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wfserver/_default.cfg
@@ -65,6 +65,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/wmcserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wmcserver/_default.cfg
@@ -67,6 +67,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/wurmserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/wurmserver/_default.cfg
@@ -104,6 +104,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/xntserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/xntserver/_default.cfg
@@ -62,6 +62,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/zmrserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/zmrserver/_default.cfg
@@ -68,6 +68,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/config-default/config-lgsm/zpsserver/_default.cfg
+++ b/lgsm/config-default/config-lgsm/zpsserver/_default.cfg
@@ -73,6 +73,10 @@ ntfypassword=""
 ntfypriority=""
 ntfytags=""
 
+# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
+flowtriqalert="off"
+flowtriqwebhook="webhook"
+
 # Pushbullet Alerts | https://docs.linuxgsm.com/alerts/pushbullet
 pushbulletalert="off"
 pushbullettoken="accesstoken"

--- a/lgsm/modules/alert.sh
+++ b/lgsm/modules/alert.sh
@@ -389,3 +389,14 @@ elif [ -z "${ntfytopic}" ] && [ "${commandname}" == "TEST-ALERT" ]; then
 	echo -e "* https://docs.linuxgsm.com/alerts/ntfy"
 	fn_script_error "ntfy topic not set"
 fi
+
+if [ "${flowtriqalert}" == "on" ] && [ -n "${flowtriqwebhook}" ]; then
+	alert_flowtriq.sh
+elif [ "${flowtriqalert}" != "on" ] && [ "${commandname}" == "TEST-ALERT" ]; then
+	fn_print_warn_nl "Flowtriq alerts not enabled"
+	fn_script_log_warn "Flowtriq alerts not enabled"
+elif [ -z "${flowtriqwebhook}" ] && [ "${commandname}" == "TEST-ALERT" ]; then
+	fn_print_error_nl "Flowtriq webhook not set"
+	echo -e "* https://docs.linuxgsm.com/alerts/flowtriq"
+	fn_script_error "Flowtriq webhook not set"
+fi

--- a/lgsm/modules/alert_flowtriq.sh
+++ b/lgsm/modules/alert_flowtriq.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# LinuxGSM alert_flowtriq.sh module
+# Author: Daniel Gibbs
+# Contributors: https://linuxgsm.com/contrib
+# Website: https://linuxgsm.com
+# Description: Sends Flowtriq alert.
+
+moduleselfname="$(basename "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+json=$(
+	cat << EOF
+{
+	"server_name": "${servername}",
+	"alert_type": "${alertaction}",
+	"game": "${gamename}",
+	"message": "${alertmessage}",
+	"server_ip": "${alertip}",
+	"server_port": "${port}",
+	"timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+EOF
+)
+
+if [ -n "${querytype}" ]; then
+	json+=$(
+		cat << EOF
+	,
+	"query_port": "${queryport}"
+EOF
+	)
+fi
+
+json+=$(
+	cat << EOF
+
+}
+EOF
+)
+
+fn_print_dots "Sending Flowtriq alert"
+
+flowtriqsend=$(curl --connect-timeout 3 -sSL -H "Content-Type: application/json" -X POST -d "$(echo -n "${json}" | jq -c .)" "${flowtriqwebhook}")
+
+if [ $? -eq 0 ] && [ -n "${flowtriqsend}" ]; then
+	fn_print_ok_nl "Sending Flowtriq alert"
+	fn_script_log_pass "Sending Flowtriq alert"
+else
+	fn_print_fail_nl "Sending Flowtriq alert: ${flowtriqsend}"
+	fn_script_log_fail "Sending Flowtriq alert: ${flowtriqsend}"
+fi


### PR DESCRIPTION
## Summary

- Adds `alert_flowtriq.sh` module that POSTs server alerts (crashes, restarts, monitor failures, updates) to a configurable Flowtriq webhook endpoint
- Adds dispatch logic in `alert.sh` following the same pattern as existing alert providers
- Adds `flowtriqalert` and `flowtriqwebhook` config entries to all 139 default server configs

## Why

Game servers are frequent DDoS targets. When LinuxGSM detects a server crash, restart, or monitor failure, this module sends the event to Flowtriq's webhook API so operators can correlate server issues with DDoS attacks detected on their network. This helps distinguish between application-level problems and network-layer attacks, reducing mean time to resolution.

## Config

```cfg
# Flowtriq Alerts | https://docs.linuxgsm.com/alerts/flowtriq
flowtriqalert="off"
flowtriqwebhook="webhook"
```

## Test plan

- [ ] Enable `flowtriqalert="on"` and set `flowtriqwebhook` to a valid endpoint
- [ ] Run `./gameserver test-alert` and verify the JSON payload is received
- [ ] Verify ShellCheck passes on `alert_flowtriq.sh`
- [ ] Verify test-alert prints appropriate warnings when Flowtriq is not configured