### PR TITLE
fix(ci): fetch full history in details-check so base ref diff works

### DIFF
--- a/.github/workflows/details-check.yml
+++ b/.github/workflows/details-check.yml
@@ -27,6 +27,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Full history so the base branch ref is available for the
+          # `git diff origin/<base>...HEAD` comparison below (a shallow
+          # checkout has no origin/<base> and the diff fails).
+          fetch-depth: 0
 
       - name: Detect targeted servers (PR only)
         id: targeted


### PR DESCRIPTION
## Problem
The `create-matrix` job in Details Check fails on **every** PR that reaches it, with:

```
fatal: ambiguous argument 'origin/develop...HEAD': unknown revision or path not in the working tree.
```

The job runs `git diff --name-only origin/${{ github.base_ref }}...HEAD` to detect which servers a PR touches, but `actions/checkout@v6` defaults to a shallow, single-branch fetch — so `origin/develop` does not exist in the runner clone and the diff exits 128.

## Fix
Set `fetch-depth: 0` on the checkout so the base branch ref (and enough history for the `...` merge-base) is available.

## Notes
- Surfaced by #4901 (which touches 139 config files + `core_modules.sh`, so it reaches this job). Not caused by that PR.
- Not a required check, so it wasn't blocking merges — but it produced a spurious red X on every config-touching PR.