### PR TITLE
fix(jbep3): correct servercfgdefault to server.cfg

### DIFF
--- a/lgsm/config-default/config-lgsm/jbep3server/_default.cfg
+++ b/lgsm/config-default/config-lgsm/jbep3server/_default.cfg
@@ -173,7 +173,7 @@ executabledir="${serverfiles}"
 executable="./srcds_run.sh"
 servercfgdir="${systemdir}/cfg"
 servercfg="${selfname}.cfg"
-servercfgdefault="server.sample.cfg"
+servercfgdefault="server.cfg"
 servercfgfullpath="${servercfgdir}/${servercfg}"
 
 ## Backup Directory


### PR DESCRIPTION
## Summary

Fixes the failing `Details Check` CI job for **jbep3** (Jabroni Brawl: Episode 3), now visible after the details-check workflow's shallow-checkout bug was fixed in #4940.

## Root cause

The details-check "Download config" step runs:

```
curl -f -o config https://raw.githubusercontent.com/GameServerManagers/Game-Server-Configs/main/<shortname>/<servercfgdefault>
```

For jbep3, `_default.cfg` set `servercfgdefault="server.sample.cfg"`, but the [Game-Server-Configs `jbep3/` directory](https://github.com/GameServerManagers/Game-Server-Configs/tree/main/jbep3) only contains `server.cfg`. So the URL `jbep3/server.sample.cfg` 404s, `curl -f` exits 22, and the job fails.

Verified:

```
server.sample.cfg -> HTTP 404
server.cfg        -> HTTP 200
```

## Fix

Change `servercfgdefault` to `server.cfg`, matching the file that exists in the configs repo. jbep3 was the **only** server using `server.sample.cfg`; every other Source-engine server (and 69 servers overall) uses `server.cfg`, so this also aligns jbep3 with the project-wide convention.

This failure is pre-existing and unrelated to recent alerts/Matrix work — it was simply masked while the details-check workflow itself was broken.
