### PR TITLE
fix(deps): support deb822 apt sources on Debian

### DIFF
--- a/lgsm/modules/check_deps.sh
+++ b/lgsm/modules/check_deps.sh
@@ -272,7 +272,7 @@ fn_deps_detector() {
 		array_deps_required=("${array_deps_required[@]/steamcmd/}")
 		steamcmdstatus=1
 		return
-	elif [ "${deptocheck}" == "steamcmd" ] && [ "${distroid}" == "debian" ] && ! grep -qE '[^deb]+non-free([^-]|$)' /etc/apt/sources.list; then
+	elif [ "${deptocheck}" == "steamcmd" ] && [ "${distroid}" == "debian" ] && ! grep -qE '[^deb]+non-free([^-]|$)' /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources 2> /dev/null; then
 		array_deps_required=("${array_deps_required[@]/steamcmd/}")
 		steamcmdstatus=1
 		return


### PR DESCRIPTION
# Description

Check Debian APT sources in `sources.list`, `sources.list.d/*.list`, and DEB822 `*.sources` files when deciding whether the SteamCMD package is available. Missing legacy paths no longer print grep errors.

Fixes #4934

## Type of change

- [x] Bug fix (a change which fixes an issue).
- [ ] New feature (a change which adds functionality).
- [ ] New Server (new server added).
- [ ] Refactor (restructures existing code).
- [ ] Comment update (typo, spelling, explanation, examples, etc).

## Testing

- Commands/tests run: `bash -n lgsm/modules/check_deps.sh`, ShellCheck, Debian 13 container checks with DEB822 sources both with and without `non-free`.
- Result: passed; fallback remains active without `non-free`, and the SteamCMD package path is detected when `non-free` is present.
- Environment used (distro/version): Debian 13 (trixie) container.

## Risk and rollback

- Risk level: low
- Rollback plan: revert this change to restore the legacy single-file check.

## Breaking changes

- [x] No breaking changes.
- [ ] Breaking changes included (describe below).

## Documentation impact

- [x] No documentation update required.
- [ ] User documentation update required.
- [ ] Developer documentation update required.

## Checklist

- [x] This pull request links to an issue.
- [x] This pull request uses the develop branch as its base.
- [x] This pull request subject follows the Conventional Commits standard.
- [x] This code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have provided a detailed enough description of this PR.
