### PR TITLE
fix(fastdl): include Source resource files

### DIFF
--- a/lgsm/modules/command_fastdl.sh
+++ b/lgsm/modules/command_fastdl.sh
@@ -162,7 +162,7 @@ fn_fastdl_preview() {
 		done
 	# Source engine
 	else
-		fastdl_directories_array=("maps" "materials" "models" "particles" "sound" "resources")
+		fastdl_directories_array=("maps" "materials" "models" "particles" "sound" "resource")
 		for directory in "${fastdl_directories_array[@]}"; do
 			if [ -d "${systemdir}/${directory}" ]; then
 				if [ "${directory}" == "maps" ]; then
@@ -175,6 +175,8 @@ fn_fastdl_preview() {
 					local allowed_extentions_array=("*.pcf")
 				elif [ "${directory}" == "sound" ]; then
 					local allowed_extentions_array=("*.wav" "*.mp3" "*.ogg")
+				elif [ "${directory}" == "resource" ]; then
+					local allowed_extentions_array=("*")
 				fi
 				for allowed_extention in "${allowed_extentions_array[@]}"; do
 					fileswc=0
@@ -323,6 +325,8 @@ fn_fastdl_source() {
 				local allowed_extentions_array=("*.pcf")
 			elif [ "${directory}" == "sound" ]; then
 				local allowed_extentions_array=("*.wav" "*.mp3" "*.ogg")
+			elif [ "${directory}" == "resource" ]; then
+				local allowed_extentions_array=("*")
 			fi
 			for allowed_extention in "${allowed_extentions_array[@]}"; do
 				fileswc=0


### PR DESCRIPTION
# Description

Include the Source `resource` directory in FastDL and copy its mixed client assets instead of looking for the non-existent `resources` directory.

Fixes #3992

## Type of change

- [x] Bug fix (a change which fixes an issue).
- [ ] New feature (a change which adds functionality).
- [ ] New Server (new server added).
- [ ] Refactor (restructures existing code).
- [ ] Comment update (typo, spelling, explanation, examples, etc).

## Testing

- Commands/tests run: isolated `fn_fastdl_preview` and `fn_fastdl_source` fixtures; `bash -n`; `npx prettier --check lgsm/modules/command_fastdl.sh`; ShellCheck
- Result: preview and copy both handled 3/3 mixed `resource` files; all checks passed
- Environment used (distro/version): Ubuntu 24.04

## Risk and rollback

- Risk level: low
- Rollback plan: revert this change

## Breaking changes

- [x] No breaking changes.
- [ ] Breaking changes included (describe below).

## Documentation impact

- [x] No documentation update required.
- [ ] User documentation update required.
- [ ] Developer documentation update required.

## Checklist

- [x] This pull request links to an issue.
- [x] This pull request uses the develop branch as its base.
- [x] This pull request subject follows the Conventional Commits standard.
- [x] This code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have provided a detailed enough description of this PR.
